### PR TITLE
Fix chat session switching for previous chats

### DIFF
--- a/components/video-chat.tsx
+++ b/components/video-chat.tsx
@@ -68,7 +68,10 @@ export function VideoChat({ youtubeId }: { youtubeId: string }) {
   const [currentChatId, setCurrentChatId] = useState<string | undefined>()
   const [input, setInput] = useState("")
 
+  const chatSessionId = currentChatId ?? `${youtubeId}-new`
+
   const { messages, sendMessage, status } = useChat({
+    id: chatSessionId,
     api: `/api/video/${youtubeId}/chat`,
     body: {
       chatId: currentChatId,
@@ -79,6 +82,7 @@ export function VideoChat({ youtubeId }: { youtubeId: string }) {
     const fetchData = async () => {
       setIsLoadingVideo(true)
       try {
+        setCurrentChatId(undefined)
         const [videoRes, chatsRes] = await Promise.all([
           fetch(`/api/video/${youtubeId}`),
           fetch(`/api/video/${youtubeId}/chats`),


### PR DESCRIPTION
## Summary
- key chat sessions by current chat selection instead of only the youtube video ID
- reset the active chat identifier when loading a different video to avoid stale messages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692591de15408326b4cc6c7dfff47762)