### PR TITLE
Debug maximum call stack error

### DIFF
--- a/app/workflows/fetch-transcript.ts
+++ b/app/workflows/fetch-transcript.ts
@@ -1,5 +1,5 @@
 import { ApifyClient } from "apify-client";
-import { fetch, getWritable } from "workflow";
+import { getWritable } from "workflow";
 import { z } from "zod";
 import { generateTranscriptToBook } from "@/ai/transcript-to-book";
 import type { TranscriptToBook } from "@/ai/transcript-to-book-schema";
@@ -218,7 +218,9 @@ async function stepGenerateBookContent(input: {
 }): Promise<TranscriptToBook> {
   "use step";
 
-  globalThis.fetch = fetch;
+  // Note: Steps have full Node.js access with native fetch.
+  // Do NOT set globalThis.fetch to workflow's fetch here - it creates
+  // infinite recursion since workflow's fetch calls globalThis.fetch.
 
   const transcriptString = formatTranscriptString(input.transcript);
 


### PR DESCRIPTION
Remove `globalThis.fetch = fetch` assignment to fix a "Maximum call stack size exceeded" error.

The assignment created an infinite recursion because the workflow's `fetch` function internally calls `globalThis.fetch`. Step functions run in a full Node.js environment and already have access to the native `fetch`, making the override unnecessary and problematic.

---
<a href="https://cursor.com/background-agent?bcId=bc-a339793f-74fa-4abd-9a74-972a342396d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a339793f-74fa-4abd-9a74-972a342396d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

