### PR TITLE
Extract slides with callback handling

### DIFF
--- a/app/workflows/extract-slides.ts
+++ b/app/workflows/extract-slides.ts
@@ -10,10 +10,6 @@ import type {
 } from "@/lib/slides-extractor-types";
 import { JobStatus } from "@/lib/slides-extractor-types";
 
-type ParserEvent =
-  | { type: "event"; data: string }
-  | { type: "reconnect-interval"; value: number };
-
 function getEnv(key: string, fallback?: string): string {
   const value = process.env[key];
   if (value) return value;
@@ -103,12 +99,8 @@ async function monitorJobProgress(videoId: string): Promise<string> {
     const reader = body.getReader();
     const decoder = new TextDecoder();
 
-    const parser = (
-      createParser as unknown as (onParse: (event: ParserEvent) => void) => {
-        feed: (chunk: string) => void;
-      }
-    )((event: ParserEvent) => {
-      if (event.type === "event") {
+    const parser = createParser({
+      onEvent: (event) => {
         void (async () => {
           try {
             const data: JobUpdate = JSON.parse(event.data);
@@ -133,7 +125,7 @@ async function monitorJobProgress(videoId: string): Promise<string> {
             // Ignore parse errors
           }
         })();
-      }
+      },
     });
 
     (async () => {


### PR DESCRIPTION
Update `eventsource-parser` API usage to v3.x to fix `callbacks` type error.

The `eventsource-parser` library was updated to v3.x, which changed the `createParser` function's signature. It now expects an object with an `onEvent` property instead of a direct callback function. This PR adapts the code to the new API and removes related obsolete code.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fe9b70b-689f-435e-9f51-7b91ce02919d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5fe9b70b-689f-435e-9f51-7b91ce02919d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

