### PR TITLE
Display only one slide

### DIFF
--- a/components/video-chat.tsx
+++ b/components/video-chat.tsx
@@ -545,17 +545,13 @@ export function VideoChat({ youtubeId }: { youtubeId: string }) {
                 </div>
               )}
 
-              {slideExtraction.status === "extracting" && (
-                <div className="flex flex-col items-center justify-center h-full min-h-[300px] text-center text-muted-foreground">
-                  <Loader2 className="h-8 w-8 animate-spin mb-4" />
-                  <p className="text-sm">Extracting slides...</p>
-                  {slides.length > 0 && (
-                    <p className="text-xs mt-2">
-                      {slides.length} slides found so far
-                    </p>
-                  )}
-                </div>
-              )}
+              {slideExtraction.status === "extracting" &&
+                slides.length === 0 && (
+                  <div className="flex flex-col items-center justify-center h-full min-h-[300px] text-center text-muted-foreground">
+                    <Loader2 className="h-8 w-8 animate-spin mb-4" />
+                    <p className="text-sm">Extracting slides...</p>
+                  </div>
+                )}
 
               {(slideExtraction.status === "ready" ||
                 (slideExtraction.status === "extracting" &&


### PR DESCRIPTION
Adjust slide extraction loading indicator condition to prevent it from obscuring slides during extraction.

Previously, the full-height loading indicator was displayed simultaneously with extracted slides during the "extracting" phase if slides were already present. This caused only one slide to be visible. The change makes the loading indicator mutually exclusive with the display of slides, only showing it when no slides have been extracted yet.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee3bd10b-d5ff-4d5d-8568-a6f198fcb39a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee3bd10b-d5ff-4d5d-8568-a6f198fcb39a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

