### PR TITLE
Fix duration formatting and run version handling

### DIFF
--- a/app/workflows/dynamic-analysis.ts
+++ b/app/workflows/dynamic-analysis.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { getWritable } from "workflow";
 import { z } from "zod";
 import {
@@ -176,7 +176,7 @@ async function getNextVersion(videoId: string): Promise<number> {
     .select({ version: videoAnalysisRuns.version })
     .from(videoAnalysisRuns)
     .where(eq(videoAnalysisRuns.videoId, videoId))
-    .orderBy(videoAnalysisRuns.version)
+    .orderBy(desc(videoAnalysisRuns.version))
     .limit(1);
 
   const maxVersion = result[0]?.version ?? 0;

--- a/components/analyze/analyze-view.tsx
+++ b/components/analyze/analyze-view.tsx
@@ -67,10 +67,10 @@ export function AnalyzeView({ youtubeId, initialVersion }: AnalyzeViewProps) {
     useTranscriptFetcher(youtubeId);
 
   // Fetch existing analysis runs
-  const fetchRuns = useCallback(async () => {
+  const fetchRuns = useCallback(async (): Promise<AnalysisRun[]> => {
     try {
       const res = await fetch(`/api/video/${youtubeId}/analyze`);
-      if (!res.ok) return;
+      if (!res.ok) return [];
       const data = await res.json();
       setRuns(data.runs);
 
@@ -81,8 +81,11 @@ export function AnalyzeView({ youtubeId, initialVersion }: AnalyzeViewProps) {
         );
         setSelectedRun(run ?? data.runs[0]);
       }
+
+      return data.runs;
     } catch (err) {
       console.error("Failed to fetch runs:", err);
+      return [];
     }
   }, [youtubeId, initialVersion]);
 
@@ -146,9 +149,9 @@ export function AnalyzeView({ youtubeId, initialVersion }: AnalyzeViewProps) {
   // When analysis completes, refresh runs
   useEffect(() => {
     if (analysisState.status === "completed" && analysisState.runId) {
-      fetchRuns().then(() => {
+      fetchRuns().then((updatedRuns) => {
         const params = new URLSearchParams(searchParams.toString());
-        const newVersion = runs.length + 1;
+        const newVersion = updatedRuns.length + 1;
         params.set("v", newVersion.toString());
         router.push(`?${params.toString()}`, { scroll: false });
       });
@@ -159,7 +162,6 @@ export function AnalyzeView({ youtubeId, initialVersion }: AnalyzeViewProps) {
     fetchRuns,
     router,
     searchParams,
-    runs.length,
   ]);
 
   // Handlers

--- a/lib/time-utils.ts
+++ b/lib/time-utils.ts
@@ -10,11 +10,11 @@ export function formatTime(seconds: number): string {
 
 // Helper function to format duration from seconds to human-readable format
 export function formatDuration(seconds: number | null): string {
-  if (!seconds) return "N/A";
+  if (seconds === null) return "N/A";
 
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
-  const secs = seconds % 60;
+  const secs = Math.floor(seconds % 60);
 
   if (hours > 0) {
     return `${hours}:${minutes.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;


### PR DESCRIPTION
## Summary
- treat null as invalid when formatting durations and floor seconds before rendering
- refresh analysis run version updates using the latest fetched runs data
- fetch the most recent analysis version by ordering runs in descending order

## Testing
- pnpm format
- pnpm fix
- pnpm tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69289383101483269cc62725e7ed3737)