### PR TITLE
Stream god prompt output to UI

### DIFF
--- a/ai/dynamic-analysis.ts
+++ b/ai/dynamic-analysis.ts
@@ -1,4 +1,4 @@
-import { generateObject } from "ai";
+import { generateObject, streamObject } from "ai";
 import {
   buildDerivedAnalysisUserMessage,
   buildGodPromptUserMessage,
@@ -37,6 +37,17 @@ export async function generateDynamicAnalysis(
   });
 
   return result.object;
+}
+
+export function streamDynamicAnalysis(input: DynamicAnalysisInput) {
+  const userPrompt = buildGodPromptUserMessage(input);
+
+  return streamObject({
+    model: "openai/gpt-5-mini",
+    schema: godPromptOutputSchema,
+    system: DYNAMIC_ANALYSIS_SYSTEM_PROMPT,
+    prompt: userPrompt,
+  });
 }
 
 export interface DerivedAnalysisInput {


### PR DESCRIPTION
## Summary
- add AI SDK streaming helper for the god prompt
- emit partial workflow events while streaming the analysis and surface them to the client hook
- merge partial updates on the UI so reasoning, schema, and analysis render progressively

## Testing
- pnpm format
- pnpm fix
- pnpm tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692898f18c8c8326b3abe9937edf2dcb)