### PR TITLE
Auto-start video analysis workflows

### DIFF
--- a/components/analyze/slides-panel.tsx
+++ b/components/analyze/slides-panel.tsx
@@ -14,7 +14,7 @@ import {
   ZoomIn,
 } from "lucide-react";
 import Image from "next/image";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -32,11 +32,29 @@ interface SlidesPanelProps {
 export function SlidesPanel({ videoId }: SlidesPanelProps) {
   const { state, slides, startExtraction, loadExistingSlides } =
     useSlideExtraction(videoId);
+  const autoStartRef = useRef(false);
+  const hasCheckedSlidesRef = useRef(false);
 
   // Load existing slides on mount
   useEffect(() => {
-    loadExistingSlides();
+    const loadSlides = async () => {
+      await loadExistingSlides();
+      hasCheckedSlidesRef.current = true;
+    };
+
+    void loadSlides();
   }, [loadExistingSlides]);
+
+  useEffect(() => {
+    if (
+      hasCheckedSlidesRef.current &&
+      !autoStartRef.current &&
+      state.status === "idle"
+    ) {
+      autoStartRef.current = true;
+      startExtraction();
+    }
+  }, [startExtraction, state.status]);
 
   // Idle state - show extract button
   if (state.status === "idle") {


### PR DESCRIPTION
## Summary
- automatically kick off transcript fetching and dynamic analysis when visiting a video analysis page without existing runs
- trigger slide extraction automatically after checking for existing slide data

## Testing
- pnpm format
- pnpm fix
- pnpm tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ad6c8ee5883268589f81713ee4306)