### PR TITLE
Add virtual scroll and search to video list

### DIFF
--- a/app/api/videos/route.ts
+++ b/app/api/videos/route.ts
@@ -1,7 +1,7 @@
 import { desc, eq, isNotNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { scrapTranscriptV1, videos } from "@/db/schema";
+import { channels, scrapTranscriptV1, videos } from "@/db/schema";
 import { formatDuration } from "@/lib/time-utils";
 
 // ============================================================================
@@ -18,9 +18,11 @@ export async function GET() {
       durationSeconds: scrapTranscriptV1.durationSeconds,
       thumbnail: scrapTranscriptV1.thumbnail,
       createdAt: scrapTranscriptV1.createdAt,
+      channelName: channels.channelName,
     })
     .from(videos)
     .innerJoin(scrapTranscriptV1, eq(videos.videoId, scrapTranscriptV1.videoId))
+    .innerJoin(channels, eq(videos.channelId, channels.channelId))
     .where(isNotNull(scrapTranscriptV1.transcript))
     .orderBy(desc(scrapTranscriptV1.createdAt))
     .limit(50);
@@ -35,6 +37,7 @@ export async function GET() {
         ? formatDuration(row.durationSeconds)
         : "N/A",
       thumbnail: row.thumbnail ?? "",
+      channelName: row.channelName,
     },
     extractSlides: false,
     completedAt: row.createdAt?.toISOString(),

--- a/components/processed-videos-list.tsx
+++ b/components/processed-videos-list.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { CheckCircle2, Clock, FileVideo } from "lucide-react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { CheckCircle2, Clock, FileVideo, Search } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 
 interface VideoData {
   videoId: string;
@@ -14,6 +16,7 @@ interface VideoData {
     description: string;
     duration: string;
     thumbnail: string;
+    channelName: string;
   };
   extractSlides: boolean;
   completedAt?: string;
@@ -22,6 +25,8 @@ interface VideoData {
 export function ProcessedVideosList() {
   const [videos, setVideos] = useState<VideoData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const parentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     async function fetchVideos() {
@@ -41,6 +46,34 @@ export function ProcessedVideosList() {
 
     fetchVideos();
   }, []);
+
+  // Filter videos based on search query
+  const filteredVideos = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return videos;
+    }
+
+    const query = searchQuery.toLowerCase();
+    return videos.filter((video) => {
+      const title = video.videoData?.title?.toLowerCase() || "";
+      const channelName = video.videoData?.channelName?.toLowerCase() || "";
+      const description = video.videoData?.description?.toLowerCase() || "";
+
+      return (
+        title.includes(query) ||
+        channelName.includes(query) ||
+        description.includes(query)
+      );
+    });
+  }, [videos, searchQuery]);
+
+  // Setup virtualizer
+  const virtualizer = useVirtualizer({
+    count: filteredVideos.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 150, // Estimated height of each video card
+    overscan: 3, // Number of items to render outside of the visible area
+  });
 
   if (loading) {
     return (
@@ -83,58 +116,114 @@ export function ProcessedVideosList() {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <FileVideo className="h-5 w-5" />
-          Processed Videos
+          Processed Videos ({filteredVideos.length})
         </CardTitle>
+        <div className="mt-4">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder="Search by title, channel, or description..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+        </div>
       </CardHeader>
       <CardContent>
-        <div className="space-y-4">
-          {videos.map((video) => (
-            <Link
-              key={video.videoId}
-              href={`/video/youtube/${video.videoId}`}
-              className="block group"
+        {filteredVideos.length === 0 ? (
+          <p className="text-muted-foreground text-center py-8">
+            No videos found matching your search
+          </p>
+        ) : (
+          <div
+            ref={parentRef}
+            className="h-[600px] overflow-auto"
+            style={{
+              contain: "strict",
+            }}
+          >
+            <div
+              style={{
+                height: `${virtualizer.getTotalSize()}px`,
+                width: "100%",
+                position: "relative",
+              }}
             >
-              <div className="flex gap-4 p-4 rounded-lg border hover:bg-accent transition-colors">
-                <div className="flex-shrink-0">
-                  <Image
-                    src={
-                      video.videoData?.thumbnail ||
-                      "/placeholder.svg?height=90&width=160"
-                    }
-                    alt={video.videoData?.title || "Video thumbnail"}
-                    width={160}
-                    height={90}
-                    className="w-40 h-24 object-cover rounded"
-                  />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <h3 className="font-semibold text-lg mb-2 truncate group-hover:text-primary transition-colors">
-                    {video.videoData?.title || "Untitled Video"}
-                  </h3>
-                  <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
-                    {video.videoData?.description || "No description available"}
-                  </p>
-                  <div className="flex items-center gap-3 text-sm">
-                    <div className="flex items-center gap-1 text-muted-foreground">
-                      <Clock className="h-4 w-4" />
-                      <span>{video.videoData?.duration || "N/A"}</span>
+              {virtualizer.getVirtualItems().map((virtualItem) => {
+                const video = filteredVideos[virtualItem.index];
+                return (
+                  <div
+                    key={virtualItem.key}
+                    data-index={virtualItem.index}
+                    ref={virtualizer.measureElement}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      transform: `translateY(${virtualItem.start}px)`,
+                    }}
+                  >
+                    <div className="pb-4">
+                      <Link
+                        href={`/video/youtube/${video.videoId}`}
+                        className="block group"
+                      >
+                        <div className="flex gap-4 p-4 rounded-lg border hover:bg-accent transition-colors">
+                          <div className="flex-shrink-0">
+                            <Image
+                              src={
+                                video.videoData?.thumbnail ||
+                                "/placeholder.svg?height=90&width=160"
+                              }
+                              alt={video.videoData?.title || "Video thumbnail"}
+                              width={160}
+                              height={90}
+                              className="w-40 h-24 object-cover rounded"
+                            />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <h3 className="font-semibold text-lg mb-1 truncate group-hover:text-primary transition-colors">
+                              {video.videoData?.title || "Untitled Video"}
+                            </h3>
+                            <p className="text-sm text-muted-foreground mb-2">
+                              {video.videoData?.channelName ||
+                                "Unknown Channel"}
+                            </p>
+                            <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
+                              {video.videoData?.description ||
+                                "No description available"}
+                            </p>
+                            <div className="flex items-center gap-3 text-sm">
+                              <div className="flex items-center gap-1 text-muted-foreground">
+                                <Clock className="h-4 w-4" />
+                                <span>
+                                  {video.videoData?.duration || "N/A"}
+                                </span>
+                              </div>
+                              <Badge
+                                variant="secondary"
+                                className="flex items-center gap-1"
+                              >
+                                <CheckCircle2 className="h-3 w-3" />
+                                Completed
+                              </Badge>
+                              {video.extractSlides && (
+                                <Badge variant="outline">With Slides</Badge>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </Link>
                     </div>
-                    <Badge
-                      variant="secondary"
-                      className="flex items-center gap-1"
-                    >
-                      <CheckCircle2 className="h-3 w-3" />
-                      Completed
-                    </Badge>
-                    {video.extractSlides && (
-                      <Badge variant="outline">With Slides</Badge>
-                    )}
                   </div>
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
- Implement virtual scrolling using @tanstack/react-virtual for better performance with large video lists
- Add client-side search functionality that filters by video title, channel name, and description
- Update API to include channel name by joining with channels table
- Display channel name in video cards
- Add search input with icon in card header
- Show filtered count in header
- Use virtual scrolling with 600px height container and estimated 150px item height