### PR TITLE
Make slides bigger with feedback below

### DIFF
--- a/components/analyze/slides-panel.tsx
+++ b/components/analyze/slides-panel.tsx
@@ -414,12 +414,12 @@ function FrameCard({
     : null;
 
   return (
-    <div className="flex gap-3">
+    <div className="flex flex-col gap-3">
       {/* Image container - preserves aspect ratio */}
-      <div className="relative flex-shrink-0 w-48 group">
+      <div className="relative w-full group">
         <button
           type="button"
-          className="relative bg-muted rounded-lg overflow-hidden cursor-zoom-in"
+          className="relative bg-muted rounded-lg overflow-hidden cursor-zoom-in w-full"
           onClick={onZoom}
         >
           {imageUrl ? (
@@ -467,8 +467,8 @@ function FrameCard({
         )}
       </div>
 
-      {/* Side annotation panel */}
-      <div className="flex-1 space-y-3 text-sm">
+      {/* Annotation panel below image */}
+      <div className="w-full space-y-3 text-sm">
         {/* Has Text annotation with validation */}
         <div className="flex items-center justify-between gap-2 p-2 rounded-md bg-muted/50">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
Modified the FrameCard component to display slides side-by-side at ~50% width each, with feedback information displayed below each slide instead of to the right. This makes the slides significantly larger and more readable.

Changes:
- Changed FrameCard from horizontal (flex) to vertical (flex-col) layout
- Made slide images full width of their columns
- Moved feedback annotations below slides
- Each slide now takes roughly 50% of the available width