### PR TITLE
Add pick slide option to annotation panel

### DIFF
--- a/app/api/video/[videoId]/slides/feedback/route.ts
+++ b/app/api/video/[videoId]/slides/feedback/route.ts
@@ -15,6 +15,7 @@ const slideFeedbackSchema = z.object({
   lastFrameHasTextValidated: z.boolean().nullable().optional(),
   lastFrameIsDuplicateValidated: z.boolean().nullable().optional(),
   framesSameness: z.enum(["same", "different"]).nullable().optional(),
+  isPicked: z.boolean().nullable().optional(),
 });
 
 // ============================================================================
@@ -98,6 +99,7 @@ export async function POST(
       lastFrameIsDuplicateValidated:
         feedback.lastFrameIsDuplicateValidated ?? null,
       framesSameness: feedback.framesSameness ?? null,
+      isPicked: feedback.isPicked ?? true,
     })
     .onConflictDoUpdate({
       target: [slideFeedback.videoId, slideFeedback.slideIndex],
@@ -109,6 +111,7 @@ export async function POST(
         lastFrameIsDuplicateValidated:
           feedback.lastFrameIsDuplicateValidated ?? null,
         framesSameness: feedback.framesSameness ?? null,
+        isPicked: feedback.isPicked ?? true,
         updatedAt: new Date(),
       },
     });

--- a/components/analyze/slides-panel.tsx
+++ b/components/analyze/slides-panel.tsx
@@ -610,6 +610,9 @@ function SlideCard({
   const [samenessFeedback, setSamenessFeedback] = useState<SamenessFeedback>(
     initialFeedback?.framesSameness ?? null,
   );
+  const [isPicked, setIsPicked] = useState<boolean>(
+    initialFeedback?.isPicked ?? true,
+  );
 
   // Sync state when initialFeedback prop changes
   useEffect(() => {
@@ -625,6 +628,7 @@ function SlideCard({
           initialFeedback.lastFrameIsDuplicateValidated ?? null,
       });
       setSamenessFeedback(initialFeedback.framesSameness ?? null);
+      setIsPicked(initialFeedback.isPicked ?? true);
     }
   }, [initialFeedback]);
 
@@ -639,6 +643,7 @@ function SlideCard({
       lastFrameIsDuplicateValidated:
         lastValidation.isDuplicateValidated ?? null,
       framesSameness: samenessFeedback,
+      isPicked,
     };
 
     // Only submit if at least one field has a value
@@ -647,7 +652,8 @@ function SlideCard({
       feedback.firstFrameIsDuplicateValidated !== null ||
       feedback.lastFrameHasTextValidated !== null ||
       feedback.lastFrameIsDuplicateValidated !== null ||
-      feedback.framesSameness !== null;
+      feedback.framesSameness !== null ||
+      feedback.isPicked !== null;
 
     if (hasAnyValue) {
       onSubmitFeedback(feedback);
@@ -656,6 +662,7 @@ function SlideCard({
     firstValidation,
     lastValidation,
     samenessFeedback,
+    isPicked,
     slide.slideIndex,
     onSubmitFeedback,
   ]);
@@ -704,7 +711,15 @@ function SlideCard({
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 bg-muted/30 border-b">
         <div className="flex items-center gap-3">
-          <span className="font-semibold">Slide #{slide.slideIndex + 1}</span>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isPicked}
+              onChange={(e) => setIsPicked(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+            />
+            <span className="font-semibold">Slide #{slide.slideIndex + 1}</span>
+          </label>
           <span className="text-sm text-muted-foreground">
             {formatTime(slide.startTime)} - {formatTime(slide.endTime)}
           </span>

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -260,6 +260,9 @@ export const slideFeedback = pgTable(
     // Sameness feedback
     framesSameness: varchar("frames_sameness", { length: 16 }), // "same" | "different"
 
+    // Slide selection - whether this slide is picked for export
+    isPicked: boolean("is_picked").default(true).notNull(),
+
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/lib/slides-types.ts
+++ b/lib/slides-types.ts
@@ -109,6 +109,7 @@ export interface SlideFeedbackData {
   lastFrameHasTextValidated: boolean | null;
   lastFrameIsDuplicateValidated: boolean | null;
   framesSameness: "same" | "different" | null;
+  isPicked: boolean | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
- Add isPicked column to slideFeedback table (defaults to true)
- Update SlideFeedbackData type to include isPicked field
- Update feedback API to handle isPicked in schema and upsert
- Add checkbox UI control in slide card header for selecting/deselecting slides
- Initialize isPicked to true by default for all slides
- Save selection state to database for persistence