### PR TITLE
Fix feedback button recursive loop issue

### DIFF
--- a/components/analyze/slides-panel.tsx
+++ b/components/analyze/slides-panel.tsx
@@ -730,9 +730,13 @@ function SlideCard({
     initialFeedback?.isLastFramePicked ?? true,
   );
 
+  // Track when we're syncing from external feedback to prevent submission loop
+  const isSyncingFromFeedback = useRef(false);
+
   // Sync state when initialFeedback prop changes
   useEffect(() => {
     if (initialFeedback) {
+      isSyncingFromFeedback.current = true;
       setFirstValidation({
         hasTextValidated: initialFeedback.firstFrameHasTextValidated ?? null,
         isDuplicateValidated:
@@ -751,6 +755,12 @@ function SlideCard({
 
   // Submit feedback when it changes
   useEffect(() => {
+    // Skip submission if we're syncing from external feedback
+    if (isSyncingFromFeedback.current) {
+      isSyncingFromFeedback.current = false;
+      return;
+    }
+
     const feedback: SlideFeedbackData = {
       slideIndex: slide.slideIndex,
       firstFrameHasTextValidated: firstValidation.hasTextValidated ?? null,


### PR DESCRIPTION
The feedback buttons were causing an infinite loop by:
1. User clicks button → updates local state
2. useEffect submits feedback → updates parent's feedbackMap
3. Parent re-renders → passes new initialFeedback prop
4. useEffect syncs from initialFeedback → updates local state
5. Loop repeats

Added isSyncingFromFeedback ref to track when state updates come from external feedback vs user interaction, preventing submission during sync to break the loop.