### PR TITLE
Add loading state for resetting slide feedback

### DIFF
--- a/app/api/video/[videoId]/slides/feedback/route.ts
+++ b/app/api/video/[videoId]/slides/feedback/route.ts
@@ -156,9 +156,7 @@ export async function PATCH(
     .where(eq(slideFeedback.videoId, videoId));
 
   // Create a map of slideIndex to slide data for quick lookup
-  const slideMap = new Map(
-    allSlides.map((slide) => [slide.slideIndex, slide]),
-  );
+  const slideMap = new Map(allSlides.map((slide) => [slide.slideIndex, slide]));
 
   // Build update promises for parallel execution
   const updatePromises = allFeedback.map((feedback) => {

--- a/components/analyze/slides-panel.tsx
+++ b/components/analyze/slides-panel.tsx
@@ -46,6 +46,7 @@ export function SlidesPanel({
   const [feedbackMap, setFeedbackMap] = useState<
     Map<number, SlideFeedbackData>
   >(new Map());
+  const [isResetting, setIsResetting] = useState(false);
 
   const loadFeedback = useCallback(async () => {
     try {
@@ -96,6 +97,7 @@ export function SlidesPanel({
   );
 
   const resetToDefaults = useCallback(async () => {
+    setIsResetting(true);
     try {
       const response = await fetch(`/api/video/${videoId}/slides/feedback`, {
         method: "PATCH",
@@ -110,6 +112,8 @@ export function SlidesPanel({
       await loadFeedback();
     } catch (error) {
       console.error("Failed to reset slide picks:", error);
+    } finally {
+      setIsResetting(false);
     }
   }, [videoId, loadFeedback]);
 
@@ -296,8 +300,13 @@ export function SlidesPanel({
               size="sm"
               onClick={resetToDefaults}
               className="gap-2"
+              disabled={isResetting}
             >
-              <RotateCcw className="h-4 w-4" />
+              {isResetting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw className="h-4 w-4" />
+              )}
               Reset Picks to Default
             </Button>
             <Button


### PR DESCRIPTION
## Summary
- add a dedicated loading state for the reset picks action in the slides panel
- disable the reset button and show a spinner while the reset request runs
- apply formatter updates to the feedback API route

## Testing
- pnpm format
- pnpm fix
- pnpm tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316b271ff8832695027868ce12eaa3)