### PR TITLE
Abstract sse stream hook

### DIFF
--- a/hooks/use-sse-stream.ts
+++ b/hooks/use-sse-stream.ts
@@ -1,0 +1,61 @@
+import { useCallback, useRef } from "react";
+import type { SSEBaseEvent, SSEHandlerMap } from "@/lib/sse";
+
+export interface UseSSEStreamReturn<T extends SSEBaseEvent> {
+  start: (
+    url: string,
+    handlers: SSEHandlerMap<T>,
+    options?: { body?: unknown; headers?: Record<string, string> },
+  ) => Promise<void>;
+  abort: () => void;
+}
+
+export function useSSEStream<T extends SSEBaseEvent>(): UseSSEStreamReturn<T> {
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const start = useCallback(
+    async (
+      url: string,
+      handlers: SSEHandlerMap<T>,
+      options: { body?: unknown; headers?: Record<string, string> } = {},
+    ): Promise<void> => {
+      // Abort any existing stream
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+
+      abortControllerRef.current = new AbortController();
+
+      const { body, headers = {} } = options;
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...headers,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: abortControllerRef.current.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      // Import consumeSSE dynamically to avoid circular imports
+      const { consumeSSE } = await import("@/lib/sse");
+
+      await consumeSSE<T>(response, handlers);
+    },
+    [],
+  );
+
+  const abort = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+  }, []);
+
+  return { start, abort };
+}


### PR DESCRIPTION
Introduce `useSSEStream` hook and refactor existing SSE streaming patterns to use it.

This abstracts duplicated SSE streaming logic into a reusable hook, centralizing stream management (including abortion) and improving code consistency across `analyze-view.tsx`, `slides-panel.tsx`, and `use-dynamic-analysis.ts`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c22995e1-96b8-4245-9d54-bbfd0e56c914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c22995e1-96b8-4245-9d54-bbfd0e56c914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

