### PR TITLE
Extract formatting utilities

### DIFF
--- a/components/analyze/analysis-panel.tsx
+++ b/components/analyze/analysis-panel.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Streamdown } from "streamdown";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { analysisToMarkdown, formatSectionTitle } from "@/lib/analysis-format";
 import { isRecord } from "@/lib/type-utils";
 import { SectionFeedback } from "./section-feedback";
 
@@ -18,69 +19,9 @@ interface AnalysisPanelProps {
   videoId: string;
 }
 
-// Convert analysis object to markdown format
-function analysisToMarkdown(analysis: Record<string, unknown>): string {
-  let markdown = "";
-
-  for (const [key, value] of Object.entries(analysis)) {
-    // Add section title
-    markdown += `## ${formatSectionTitle(key)}\n\n`;
-
-    // Convert content to markdown
-    markdown += contentToMarkdown(value);
-    markdown += "\n\n";
-  }
-
-  return markdown.trim();
-}
-
 // ============================================================================
 // Content Conversion Utilities
 // ============================================================================
-
-// Convert various content types to markdown
-function contentToMarkdown(content: unknown): string {
-  if (content === null || content === undefined || content === "") {
-    return "_No content_";
-  }
-
-  if (typeof content === "string") {
-    return content;
-  }
-
-  if (Array.isArray(content)) {
-    if (content.length === 0) {
-      return "_No items_";
-    }
-    return content
-      .map((item) => {
-        if (typeof item === "string") {
-          // Check if already starts with - * or numbered list
-          return item.trim().match(/^\s*[-*]\s+|^\s*\d+\.\s+|^\s*\d+\)\s+/)
-            ? item
-            : `- ${item}`;
-        }
-        return `\`\`\`json\n${JSON.stringify(item, null, 2)}\n\`\`\``;
-      })
-      .join("\n");
-  }
-
-  if (isRecord(content)) {
-    let markdown = "";
-    for (const [key, value] of Object.entries(content)) {
-      markdown += `**${key}**: `;
-      if (typeof value === "string") {
-        markdown += value;
-      } else {
-        markdown += `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
-      }
-      markdown += "\n\n";
-    }
-    return markdown;
-  }
-
-  return String(content);
-}
 
 // ============================================================================
 // Main Panel Component
@@ -295,19 +236,4 @@ export function ObjectSection({ data }: { data: Record<string, unknown> }) {
       })}
     </dl>
   );
-}
-
-// ============================================================================
-// Utility Functions
-// ============================================================================
-
-// Convert snake_case to Title Case
-function formatSectionTitle(key: string): string {
-  if (!key || typeof key !== "string") {
-    return "";
-  }
-  return key
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
 }

--- a/lib/analysis-format.test.ts
+++ b/lib/analysis-format.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analysisToMarkdown,
+  contentToMarkdown,
+  formatSectionTitle,
+} from "./analysis-format";
+
+describe("formatSectionTitle", () => {
+  it("should convert snake_case to Title Case", () => {
+    expect(formatSectionTitle("key_takeaways")).toBe("Key Takeaways");
+    expect(formatSectionTitle("action_items")).toBe("Action Items");
+    expect(formatSectionTitle("tldr")).toBe("Tldr");
+  });
+
+  it("should convert kebab-case to Title Case", () => {
+    expect(formatSectionTitle("key-takeaways")).toBe("Key Takeaways");
+    expect(formatSectionTitle("my-section")).toBe("My Section");
+  });
+
+  it("should handle single words", () => {
+    expect(formatSectionTitle("summary")).toBe("Summary");
+    expect(formatSectionTitle("facts")).toBe("Facts");
+  });
+
+  it("should return empty string for empty input", () => {
+    expect(formatSectionTitle("")).toBe("");
+  });
+
+  it("should return empty string for null/undefined", () => {
+    expect(formatSectionTitle(null as unknown as string)).toBe("");
+    expect(formatSectionTitle(undefined as unknown as string)).toBe("");
+  });
+
+  it("should handle multiple underscores", () => {
+    expect(formatSectionTitle("my_long_section_name")).toBe(
+      "My Long Section Name",
+    );
+  });
+});
+
+describe("contentToMarkdown", () => {
+  it("should return _No content_ for null/undefined/empty", () => {
+    expect(contentToMarkdown(null)).toBe("_No content_");
+    expect(contentToMarkdown(undefined)).toBe("_No content_");
+    expect(contentToMarkdown("")).toBe("_No content_");
+  });
+
+  it("should return string content as-is", () => {
+    expect(contentToMarkdown("Hello world")).toBe("Hello world");
+    expect(contentToMarkdown("**bold** text")).toBe("**bold** text");
+  });
+
+  it("should return _No items_ for empty array", () => {
+    expect(contentToMarkdown([])).toBe("_No items_");
+  });
+
+  it("should convert string array to bullet list", () => {
+    const result = contentToMarkdown(["item 1", "item 2", "item 3"]);
+    expect(result).toBe("- item 1\n- item 2\n- item 3");
+  });
+
+  it("should not add bullet to items already starting with bullet", () => {
+    const result = contentToMarkdown(["- item 1", "* item 2", "item 3"]);
+    expect(result).toBe("- item 1\n* item 2\n- item 3");
+  });
+
+  it("should not add bullet to numbered list items", () => {
+    const result = contentToMarkdown(["1. first", "2) second", "third"]);
+    expect(result).toBe("1. first\n2) second\n- third");
+  });
+
+  it("should convert object array items to JSON blocks", () => {
+    const result = contentToMarkdown([{ name: "test" }]);
+    expect(result).toContain("```json");
+    expect(result).toContain('"name": "test"');
+    expect(result).toContain("```");
+  });
+
+  it("should convert object to key-value markdown", () => {
+    const result = contentToMarkdown({ name: "John", age: "30" });
+    expect(result).toContain("**name**: John");
+    expect(result).toContain("**age**: 30");
+  });
+
+  it("should convert object with non-string values to JSON", () => {
+    const result = contentToMarkdown({ data: { nested: true } });
+    expect(result).toContain("**data**:");
+    expect(result).toContain("```json");
+  });
+
+  it("should convert numbers to string", () => {
+    expect(contentToMarkdown(42)).toBe("42");
+  });
+
+  it("should convert booleans to string", () => {
+    expect(contentToMarkdown(true)).toBe("true");
+    expect(contentToMarkdown(false)).toBe("false");
+  });
+});
+
+describe("analysisToMarkdown", () => {
+  it("should convert analysis object to markdown with headers", () => {
+    const analysis = {
+      tldr: "This is the summary",
+      key_takeaways: ["Point 1", "Point 2"],
+    };
+    const result = analysisToMarkdown(analysis);
+    expect(result).toContain("## Tldr");
+    expect(result).toContain("This is the summary");
+    expect(result).toContain("## Key Takeaways");
+    expect(result).toContain("- Point 1");
+    expect(result).toContain("- Point 2");
+  });
+
+  it("should handle empty analysis object", () => {
+    expect(analysisToMarkdown({})).toBe("");
+  });
+
+  it("should handle nested objects", () => {
+    const analysis = {
+      metadata: {
+        title: "Test",
+        duration: "10:00",
+      },
+    };
+    const result = analysisToMarkdown(analysis);
+    expect(result).toContain("## Metadata");
+    expect(result).toContain("**title**: Test");
+    expect(result).toContain("**duration**: 10:00");
+  });
+
+  it("should handle mixed content types", () => {
+    const analysis = {
+      summary: "A summary",
+      items: ["item 1", "item 2"],
+      details: { key: "value" },
+    };
+    const result = analysisToMarkdown(analysis);
+    expect(result).toContain("## Summary");
+    expect(result).toContain("A summary");
+    expect(result).toContain("## Items");
+    expect(result).toContain("- item 1");
+    expect(result).toContain("## Details");
+    expect(result).toContain("**key**: value");
+  });
+});

--- a/lib/analysis-format.ts
+++ b/lib/analysis-format.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure formatting utilities for video analysis data.
+ * These functions are extracted from components for testability.
+ */
+
+import { isRecord } from "./type-utils";
+
+/**
+ * Converts snake_case or kebab-case to Title Case.
+ * @example formatSectionTitle("key_takeaways") => "Key Takeaways"
+ * @example formatSectionTitle("my-section") => "My Section"
+ */
+export function formatSectionTitle(key: string): string {
+  if (!key || typeof key !== "string") {
+    return "";
+  }
+
+  return key
+    .split(/[_-]/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
+ * Converts various content types to markdown format.
+ * Handles strings, arrays, and objects.
+ */
+export function contentToMarkdown(content: unknown): string {
+  if (content === null || content === undefined || content === "") {
+    return "_No content_";
+  }
+
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    if (content.length === 0) {
+      return "_No items_";
+    }
+
+    return content
+      .map((item) => {
+        if (typeof item === "string") {
+          // Check if already starts with - * or numbered list
+          return item.trim().match(/^\s*[-*]\s+|^\s*\d+\.\s+|^\s*\d+\)\s+/)
+            ? item
+            : `- ${item}`;
+        }
+        return `\`\`\`json\n${JSON.stringify(item, null, 2)}\n\`\`\``;
+      })
+      .join("\n");
+  }
+
+  if (isRecord(content)) {
+    let markdown = "";
+
+    for (const [key, value] of Object.entries(content)) {
+      markdown += `**${key}**: `;
+
+      if (typeof value === "string") {
+        markdown += value;
+      } else {
+        markdown += `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+      }
+
+      markdown += "\n\n";
+    }
+
+    return markdown;
+  }
+
+  return String(content);
+}
+
+/**
+ * Converts an analysis object to markdown format.
+ * Each top-level key becomes a section with an h2 header.
+ */
+export function analysisToMarkdown(analysis: Record<string, unknown>): string {
+  let markdown = "";
+
+  for (const [key, value] of Object.entries(analysis)) {
+    markdown += `## ${formatSectionTitle(key)}\n\n`;
+
+    markdown += contentToMarkdown(value);
+
+    markdown += "\n\n";
+  }
+
+  return markdown.trim();
+}


### PR DESCRIPTION
Extract markdown formatting utilities to `lib/analysis-format.ts` to improve testability and reusability.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebb821ba-82d9-4ac9-a75d-1a770ff87ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebb821ba-82d9-4ac9-a75d-1a770ff87ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

