### PR TITLE
Extract transcript formatting utilities

### DIFF
--- a/app/workflows/fetch-and-analyze.ts
+++ b/app/workflows/fetch-and-analyze.ts
@@ -1,5 +1,6 @@
 import { getWritable } from "workflow";
 import type { TranscriptResult } from "@/db/save-transcript";
+import { formatTranscriptForLLMPadded } from "@/lib/transcript-format";
 import {
   completeRun,
   createAnalysisRun,
@@ -141,15 +142,7 @@ export async function fetchAndAnalyzeWorkflow(
       channelName: transcriptData.channelName,
       description: transcriptData.description,
       // Format transcript with timestamps for LLM
-      transcript: transcriptData.transcript
-        .map((seg) => {
-          const hours = Math.floor(seg.start / 3600);
-          const minutes = Math.floor((seg.start % 3600) / 60);
-          const seconds = Math.floor(seg.start % 60);
-          const time = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
-          return `[${time}] ${seg.text}`;
-        })
-        .join("\n"),
+      transcript: formatTranscriptForLLMPadded(transcriptData.transcript),
     };
 
     const result = await runGodPrompt(dataForAnalysis, additionalInstructions);

--- a/app/workflows/steps/dynamic-analysis/analysis-processing.ts
+++ b/app/workflows/steps/dynamic-analysis/analysis-processing.ts
@@ -8,6 +8,7 @@ import {
   videoAnalysisRuns,
   videos,
 } from "@/db/schema";
+import { formatTranscriptForLLM } from "@/lib/transcript-format";
 
 // ============================================================================
 // Transcript Schema (for validation)
@@ -18,29 +19,6 @@ const TranscriptSegmentSchema = z.object({
   end: z.number(),
   text: z.string(),
 });
-
-// ============================================================================
-// Helper: Format transcript for LLM
-// ============================================================================
-
-function formatTimestamp(seconds: number): string {
-  const hours = Math.floor(seconds / 3600);
-  const mins = Math.floor((seconds % 3600) / 60);
-  const secs = Math.floor(seconds % 60);
-
-  if (hours > 0) {
-    return `${hours}:${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
-  }
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
-}
-
-function formatTranscriptForLLM(
-  segments: Array<{ start: number; text: string }>,
-): string {
-  return segments
-    .map((segment) => `[${formatTimestamp(segment.start)}] ${segment.text}`)
-    .join("\n");
-}
 
 // ============================================================================
 // Transcript Data Interface

--- a/lib/transcript-format.test.ts
+++ b/lib/transcript-format.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateTranscriptDuration,
+  estimateWordCount,
+  extractPlainText,
+  formatTimestamp,
+  formatTimestampForLLM,
+  formatTranscriptForLLM,
+  formatTranscriptForLLMPadded,
+} from "./transcript-format";
+
+describe("formatTimestamp", () => {
+  it("should format seconds only", () => {
+    expect(formatTimestamp(45)).toBe("0:45");
+    expect(formatTimestamp(5)).toBe("0:05");
+  });
+
+  it("should format minutes and seconds", () => {
+    expect(formatTimestamp(125)).toBe("2:05");
+    expect(formatTimestamp(600)).toBe("10:00");
+  });
+
+  it("should format hours, minutes, and seconds", () => {
+    expect(formatTimestamp(3665)).toBe("1:01:05");
+    expect(formatTimestamp(7200)).toBe("2:00:00");
+  });
+
+  it("should handle zero", () => {
+    expect(formatTimestamp(0)).toBe("0:00");
+  });
+
+  it("should floor decimal values", () => {
+    expect(formatTimestamp(45.9)).toBe("0:45");
+  });
+});
+
+describe("formatTimestampForLLM", () => {
+  it("should always include hours with padding", () => {
+    expect(formatTimestampForLLM(45)).toBe("00:00:45");
+    expect(formatTimestampForLLM(125)).toBe("00:02:05");
+    expect(formatTimestampForLLM(3665)).toBe("01:01:05");
+  });
+
+  it("should handle zero", () => {
+    expect(formatTimestampForLLM(0)).toBe("00:00:00");
+  });
+});
+
+describe("formatTranscriptForLLM", () => {
+  it("should format segments with timestamps", () => {
+    const segments = [
+      { start: 0, text: "Hello" },
+      { start: 5, text: "World" },
+    ];
+    expect(formatTranscriptForLLM(segments)).toBe("[0:00] Hello\n[0:05] World");
+  });
+
+  it("should handle empty array", () => {
+    expect(formatTranscriptForLLM([])).toBe("");
+  });
+
+  it("should handle long timestamps", () => {
+    const segments = [{ start: 3665, text: "Long video" }];
+    expect(formatTranscriptForLLM(segments)).toBe("[1:01:05] Long video");
+  });
+});
+
+describe("formatTranscriptForLLMPadded", () => {
+  it("should format segments with padded timestamps", () => {
+    const segments = [
+      { start: 0, text: "Hello" },
+      { start: 5, text: "World" },
+    ];
+    expect(formatTranscriptForLLMPadded(segments)).toBe(
+      "[00:00:00] Hello\n[00:00:05] World",
+    );
+  });
+});
+
+describe("calculateTranscriptDuration", () => {
+  it("should return 0 for empty array", () => {
+    expect(calculateTranscriptDuration([])).toBe(0);
+  });
+
+  it("should use end time of last segment if available", () => {
+    const segments = [
+      { start: 0, end: 5, text: "First" },
+      { start: 5, end: 15, text: "Last" },
+    ];
+    expect(calculateTranscriptDuration(segments)).toBe(15);
+  });
+
+  it("should fallback to start time if no end", () => {
+    const segments = [
+      { start: 0, text: "First" },
+      { start: 10, text: "Last" },
+    ];
+    expect(calculateTranscriptDuration(segments)).toBe(10);
+  });
+});
+
+describe("extractPlainText", () => {
+  it("should concatenate all text with spaces", () => {
+    const segments = [
+      { start: 0, text: "Hello" },
+      { start: 5, text: "World" },
+    ];
+    expect(extractPlainText(segments)).toBe("Hello World");
+  });
+
+  it("should handle empty array", () => {
+    expect(extractPlainText([])).toBe("");
+  });
+});
+
+describe("estimateWordCount", () => {
+  it("should count words in transcript", () => {
+    const segments = [
+      { start: 0, text: "Hello world" },
+      { start: 5, text: "This is a test" },
+    ];
+    expect(estimateWordCount(segments)).toBe(6);
+  });
+
+  it("should handle empty array", () => {
+    expect(estimateWordCount([])).toBe(0);
+  });
+
+  it("should handle multiple spaces", () => {
+    const segments = [{ start: 0, text: "Hello   world" }];
+    expect(estimateWordCount(segments)).toBe(2);
+  });
+});

--- a/lib/transcript-format.ts
+++ b/lib/transcript-format.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure utility functions for transcript formatting.
+ * Extracted from workflow steps for testability and reuse.
+ */
+
+export interface TranscriptSegment {
+  start: number;
+  end?: number;
+  text: string;
+}
+
+/**
+ * Formats a timestamp in seconds to a human-readable string.
+ * @param seconds - Number of seconds
+ * @returns Formatted timestamp (e.g., "1:23" or "1:23:45")
+ *
+ * @example
+ * formatTimestamp(83) => "1:23"
+ * formatTimestamp(3723) => "1:02:03"
+ */
+export function formatTimestamp(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
+  if (hours > 0) {
+    return `${hours}:${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+  }
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Formats a timestamp for LLM consumption (always HH:MM:SS).
+ * @param seconds - Number of seconds
+ * @returns Formatted timestamp with leading zeros (e.g., "00:01:23")
+ */
+export function formatTimestampForLLM(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
+  return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+}
+
+/**
+ * Formats transcript segments into a string suitable for LLM analysis.
+ * Each segment is prefixed with its timestamp.
+ *
+ * @param segments - Array of transcript segments
+ * @returns Formatted transcript string with timestamps
+ *
+ * @example
+ * formatTranscriptForLLM([
+ *   { start: 0, text: "Hello" },
+ *   { start: 5, text: "World" }
+ * ])
+ * // => "[0:00] Hello\n[0:05] World"
+ */
+export function formatTranscriptForLLM(segments: TranscriptSegment[]): string {
+  return segments
+    .map((segment) => `[${formatTimestamp(segment.start)}] ${segment.text}`)
+    .join("\n");
+}
+
+/**
+ * Formats transcript segments with full HH:MM:SS timestamps.
+ * Used when consistent timestamp width is needed.
+ *
+ * @param segments - Array of transcript segments
+ * @returns Formatted transcript string with padded timestamps
+ */
+export function formatTranscriptForLLMPadded(
+  segments: TranscriptSegment[],
+): string {
+  return segments
+    .map(
+      (segment) => `[${formatTimestampForLLM(segment.start)}] ${segment.text}`,
+    )
+    .join("\n");
+}
+
+/**
+ * Calculates the total duration of a transcript.
+ * @param segments - Array of transcript segments
+ * @returns Total duration in seconds, or 0 if empty
+ */
+export function calculateTranscriptDuration(
+  segments: TranscriptSegment[],
+): number {
+  if (segments.length === 0) return 0;
+
+  const lastSegment = segments[segments.length - 1];
+  return lastSegment.end ?? lastSegment.start;
+}
+
+/**
+ * Extracts plain text from transcript segments.
+ * @param segments - Array of transcript segments
+ * @returns Concatenated text without timestamps
+ */
+export function extractPlainText(segments: TranscriptSegment[]): string {
+  return segments.map((s) => s.text).join(" ");
+}
+
+/**
+ * Estimates word count from transcript segments.
+ * @param segments - Array of transcript segments
+ * @returns Approximate word count
+ */
+export function estimateWordCount(segments: TranscriptSegment[]): number {
+  const text = extractPlainText(segments);
+  return text.split(/\s+/).filter(Boolean).length;
+}


### PR DESCRIPTION
Extract transcript formatting logic into `lib/transcript-format.ts` to improve testability and reuse across workflows.

---
<a href="https://cursor.com/background-agent?bcId=bc-8179e085-9848-4a74-9b4e-04f5c6b29ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8179e085-9848-4a74-9b4e-04f5c6b29ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

