### PR TITLE
Handle fetch errors explicitly

### DIFF
--- a/hooks/use-slides-loader.ts
+++ b/hooks/use-slides-loader.ts
@@ -18,7 +18,24 @@ export function useSlidesLoader(
   const loadExistingSlides = useCallback(async () => {
     try {
       const res = await fetch(`/api/video/${youtubeId}/slides`);
-      if (!res.ok) return;
+      if (!res.ok) {
+        let errorMessage = `Failed to load slides (${res.status})`;
+        try {
+          const errorData = await res.text();
+          if (errorData) {
+            errorMessage += `: ${errorData}`;
+          }
+        } catch {
+          // Ignore errors when trying to read response body
+        }
+        onSlidesStateChange((prev) => ({
+          ...prev,
+          status: "error",
+          error: errorMessage,
+          slides: [],
+        }));
+        return;
+      }
 
       const data = await res.json();
       const slides = Array.isArray(data.slides) ? data.slides : [];


### PR DESCRIPTION
Handle fetch failures in `useSlidesLoader` by setting an explicit error state and including response details, preventing silent failures in the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8744caf-13b6-43dc-b9f8-3405aedd13ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8744caf-13b6-43dc-b9f8-3405aedd13ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

