### PR TITLE
Optimize video processing hooks

### DIFF
--- a/hooks/use-video-processing.ts
+++ b/hooks/use-video-processing.ts
@@ -104,6 +104,11 @@ export function useVideoProcessing(
   );
   const { loadExistingSlides } = useSlidesLoader(youtubeId, setSlidesState);
   const videoStatus = useVideoStatus(youtubeId, initialVersion);
+  const {
+    fetchRuns,
+    handleVersionChange: handleVideoVersionChange,
+    setSelectedRun,
+  } = videoStatus;
 
   // ============================================================================
   // Enhanced checkVideoStatus that coordinates with other hooks
@@ -115,7 +120,7 @@ export function useVideoProcessing(
     // If ready, also load runs and slides
     if (result.status === "ready") {
       const [runsResult] = await Promise.all([
-        videoStatus.fetchRuns(),
+        fetchRuns(),
         loadExistingSlides(),
       ]);
 
@@ -125,7 +130,7 @@ export function useVideoProcessing(
     }
 
     return result;
-  }, [checkTranscriptStatus, videoStatus.fetchRuns, loadExistingSlides]);
+  }, [checkTranscriptStatus, fetchRuns, loadExistingSlides]);
 
   // ============================================================================
   // Effects
@@ -154,11 +159,11 @@ export function useVideoProcessing(
   // When analysis completes, refresh runs
   useEffect(() => {
     if (analysisState.status === "completed" && analysisState.runId) {
-      videoStatus.fetchRuns().then(({ runs: updatedRuns }) => {
+      fetchRuns().then(({ runs: updatedRuns }) => {
         // Select the latest run to match the new `v` param
         const latestRun = updatedRuns[updatedRuns.length - 1] ?? null;
         if (latestRun) {
-          videoStatus.setSelectedRun(latestRun);
+          setSelectedRun(latestRun);
         }
 
         const params = new URLSearchParams(searchParams.toString());
@@ -170,8 +175,8 @@ export function useVideoProcessing(
   }, [
     analysisState.status,
     analysisState.runId,
-    videoStatus.fetchRuns,
-    videoStatus.setSelectedRun,
+    fetchRuns,
+    setSelectedRun,
     router,
     searchParams,
   ]);
@@ -182,12 +187,12 @@ export function useVideoProcessing(
 
   const handleVersionChange = useCallback(
     (version: number) => {
-      videoStatus.handleVersionChange(version);
+      handleVideoVersionChange(version);
       const params = new URLSearchParams(searchParams.toString());
       params.set("v", version.toString());
       router.push(`?${params.toString()}`, { scroll: false });
     },
-    [videoStatus, router, searchParams],
+    [handleVideoVersionChange, router, searchParams],
   );
 
   const handleStartAnalysis = useCallback(() => {


### PR DESCRIPTION
Destructure `videoStatus` methods and update dependency arrays to prevent unnecessary re-renders and improve performance.

The `videoStatus` object is recreated on every render, making its methods unstable references when included directly in `useCallback` and `useEffect` dependency arrays. By destructuring these methods immediately after `videoStatus` creation, we obtain stable function references, which then correctly optimize the hooks by preventing unnecessary re-executions.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d15a561-3a04-4710-935f-6750ce834294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d15a561-3a04-4710-935f-6750ce834294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

