### PR TITLE
Consolidate transcript state type

### DIFF
--- a/hooks/use-transcript-fetch.ts
+++ b/hooks/use-transcript-fetch.ts
@@ -13,9 +13,9 @@ export type PageStatus =
   | "fetching_transcript"
   | "ready";
 
-type TranscriptStatus = "idle" | "fetching" | "completed" | "error";
+export type TranscriptStatus = "idle" | "fetching" | "completed" | "error";
 
-interface TranscriptState {
+export interface TranscriptState {
   status: TranscriptStatus;
   progress: number;
   message: string;

--- a/hooks/use-video-processing.ts
+++ b/hooks/use-video-processing.ts
@@ -13,7 +13,11 @@ import { useVideoStatus } from "./use-video-status";
 // Import types for backward compatibility
 // ============================================================================
 
-import type { PageStatus, VideoInfo } from "./use-transcript-fetch";
+import type {
+  PageStatus,
+  TranscriptState,
+  VideoInfo,
+} from "./use-transcript-fetch";
 import type { AnalysisRun } from "./use-video-status";
 
 // ============================================================================
@@ -47,13 +51,6 @@ export interface UseVideoProcessingReturn {
   handleReroll: (instructions: string) => void;
   setSlidesState: React.Dispatch<React.SetStateAction<SlidesState>>;
 }
-
-type TranscriptState = {
-  status: "idle" | "fetching" | "completed" | "error";
-  progress: number;
-  message: string;
-  error: string | null;
-};
 
 // ============================================================================
 // Main Hook - Now orchestrates smaller hooks


### PR DESCRIPTION
Export `TranscriptState` and `TranscriptStatus` types to eliminate duplication and prevent type drift.

The `TranscriptState` type was defined in two separate files, creating a risk of inconsistencies if one definition was updated without the other. Centralizing its definition ensures a single source of truth.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5b39f86-87f4-4b95-91d2-7b964131d29f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5b39f86-87f4-4b95-91d2-7b964131d29f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

