### PR TITLE
Isolate fetch mock

### DIFF
--- a/hooks/use-video-status.test.ts
+++ b/hooks/use-video-status.test.ts
@@ -1,16 +1,27 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import { type AnalysisRun, useVideoStatus } from "./use-video-status";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  type AnalysisRun,
+  type StreamingRunInfo,
+  useVideoStatus,
+} from "./use-video-status";
 
-interface StreamingRunInfo {
-  id: number;
-  version: number;
-  workflowRunId: string | null;
-}
+type FetchResult = {
+  runs: AnalysisRun[];
+  streamingRun: StreamingRunInfo | null;
+};
 
 // Mock global fetch
+const originalFetch = global.fetch;
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+
+beforeAll(() => {
+  global.fetch = mockFetch as typeof global.fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
 
 describe("useVideoStatus", () => {
   beforeEach(() => {
@@ -57,10 +68,7 @@ describe("useVideoStatus", () => {
 
       const { result } = renderHook(() => useVideoStatus("test-video-id", 2));
 
-      let fetchResult: {
-        runs: AnalysisRun[];
-        streamingRun: StreamingRunInfo | null;
-      } = {
+      let fetchResult: FetchResult = {
         runs: [],
         streamingRun: null,
       };
@@ -119,10 +127,7 @@ describe("useVideoStatus", () => {
 
       const { result } = renderHook(() => useVideoStatus("test-video-id"));
 
-      let fetchResult: {
-        runs: AnalysisRun[];
-        streamingRun: StreamingRunInfo | null;
-      } = {
+      let fetchResult: FetchResult = {
         runs: [],
         streamingRun: null,
       };
@@ -144,10 +149,7 @@ describe("useVideoStatus", () => {
 
       const { result } = renderHook(() => useVideoStatus("test-video-id"));
 
-      let fetchResult: {
-        runs: AnalysisRun[];
-        streamingRun: StreamingRunInfo | null;
-      } = {
+      let fetchResult: FetchResult = {
         runs: [],
         streamingRun: null,
       };
@@ -173,10 +175,7 @@ describe("useVideoStatus", () => {
 
       const { result } = renderHook(() => useVideoStatus("test-video-id"));
 
-      let fetchResult: {
-        runs: AnalysisRun[];
-        streamingRun: StreamingRunInfo | null;
-      } = {
+      let fetchResult: FetchResult = {
         runs: [],
         streamingRun: null,
       };

--- a/hooks/use-video-status.ts
+++ b/hooks/use-video-status.ts
@@ -12,7 +12,7 @@ export interface AnalysisRun {
   createdAt: string;
 }
 
-interface StreamingRunInfo {
+export interface StreamingRunInfo {
   id: number;
   version: number;
   workflowRunId: string | null;


### PR DESCRIPTION
Isolate `global.fetch` mocking in tests, export `StreamingRunInfo`, and add `FetchResult` type alias.

This PR improves test isolation by ensuring `global.fetch` mocks do not leak across test suites, enhances type safety by exporting `StreamingRunInfo` from the source file, and boosts readability by introducing a `FetchResult` type alias for repetitive test structures.

---
<a href="https://cursor.com/background-agent?bcId=bc-e25c6ee4-f96c-434e-a38f-e578917079eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e25c6ee4-f96c-434e-a38f-e578917079eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

