### PR TITLE
Fix ai event streaming

### DIFF
--- a/ai/dynamic-analysis.ts
+++ b/ai/dynamic-analysis.ts
@@ -1,4 +1,5 @@
 import { streamObject } from "ai";
+import { z } from "zod";
 import {
   buildGodPromptUserMessage,
   DYNAMIC_ANALYSIS_SYSTEM_PROMPT,
@@ -12,12 +13,15 @@ export interface DynamicAnalysisInput {
   additionalInstructions?: string;
 }
 
+// Flexible schema that allows any JSON object structure since the analysis output is dynamic
+const dynamicAnalysisSchema = z.any();
+
 export function streamDynamicAnalysis(input: DynamicAnalysisInput) {
   const userPrompt = buildGodPromptUserMessage(input);
 
   return streamObject({
     model: "openai/gpt-5.1",
-    output: "no-schema",
+    schema: dynamicAnalysisSchema,
     system: DYNAMIC_ANALYSIS_SYSTEM_PROMPT,
     prompt: userPrompt,
   });


### PR DESCRIPTION
Fix streaming of AI analysis events by ensuring JSON object output from `streamObject`.

The `streamObject` function was configured with `output: "no-schema"`, which caused the AI to generate unstructured text instead of the expected structured JSON. This led to parsing failures on the client side. By replacing `output: "no-schema"` with `schema: z.any()`, the AI is now prompted to return a JSON object, resolving the streaming issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-c71f3872-2b1c-4f4f-8194-c829c6d783e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c71f3872-2b1c-4f4f-8194-c829c6d783e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

