### PR TITLE
Fix response schema error

### DIFF
--- a/ai/dynamic-analysis.ts
+++ b/ai/dynamic-analysis.ts
@@ -14,7 +14,7 @@ export interface DynamicAnalysisInput {
 }
 
 // Flexible schema that allows any JSON object structure since the analysis output is dynamic
-const dynamicAnalysisSchema = z.any();
+const dynamicAnalysisSchema = z.object({}).passthrough();
 
 export function streamDynamicAnalysis(input: DynamicAnalysisInput) {
   const userPrompt = buildGodPromptUserMessage(input);


### PR DESCRIPTION
Fixes "Invalid schema for response_format" error by changing `z.any()` to `z.object({}).passthrough()` for `dynamicAnalysisSchema`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fdc5608-9a52-4d97-b13e-036f22603bc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0fdc5608-9a52-4d97-b13e-036f22603bc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

