### PR TITLE
Avoid flashing analysis state for existing videos

### DIFF
--- a/hooks/use-video-processing.ts
+++ b/hooks/use-video-processing.ts
@@ -211,8 +211,8 @@ export function useVideoProcessing(
   const isAnalysisRunning = analysisState.status === "running";
   const hasRuns = runs.length > 0;
   const displayResult: unknown = isAnalysisRunning
-    ? analysisState.result
-    : (selectedRun?.result ?? null);
+    ? (analysisState.result ?? selectedRun?.result ?? null)
+    : (selectedRun?.result ?? analysisState.result ?? null);
 
   // ============================================================================
   // Return


### PR DESCRIPTION
## Summary
- keep analysis results visible when an analysis stream is considered running but has no partial output yet
- reduce UI flash for previously processed videos by falling back to the selected run's saved result

## Testing
- pnpm format
- pnpm fix
- pnpm tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c7fcf6bc832681e76686278d489a)