### PR TITLE
Video processing hook type

### DIFF
--- a/hooks/use-video-processing.ts
+++ b/hooks/use-video-processing.ts
@@ -665,7 +665,7 @@ export function useVideoProcessing(
             // Select latest (run with highest ID, regardless of array order)
             selectedRunId =
               runsData.runs.reduce(
-                (maxId, run) => (run.id > maxId ? run.id : maxId),
+                (maxId: number, run: AnalysisRun) => (run.id > maxId ? run.id : maxId),
                 runsData.runs[0]?.id ?? 0,
               ) ?? null;
           }
@@ -739,8 +739,7 @@ export function useVideoProcessing(
       phase: state.analysisProgress?.phase ?? "",
       message: state.analysisProgress?.message ?? "",
       result: state.analysisProgress?.partial ?? null,
-      runId: state.analysisProgress?.runId
-        ?? (state.runs.length > 0 ? state.runs[0].id : null),
+      runId: state.selectedRunId,
       error: state.error,
     }),
     [


### PR DESCRIPTION
Fix TypeScript errors by adding explicit types to a `reduce` callback and correcting an invalid property access.

The `reduce` callback parameter `maxId` was implicitly `any`, causing a type error. Additionally, `state.analysisProgress?.runId` was an invalid property access, which has been replaced with the correct `state.selectedRunId`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8fc66ac-dc91-4864-9097-aa5c4af53488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8fc66ac-dc91-4864-9097-aa5c4af53488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

