### PR TITLE
Silence test output and wrap hook updates

### DIFF
--- a/lib/youtube-utils.test.ts
+++ b/lib/youtube-utils.test.ts
@@ -307,11 +307,18 @@ describe("validateYoutubeVideoId", () => {
   });
 
   it("should handle fetch errors gracefully", async () => {
+    // Suppress error stack traces for this specific test
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
     const mockFetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
     global.fetch = mockFetch;
 
     const isValid = await validateYoutubeVideoId("dQw4w9WgXcQ");
     expect(isValid).toBe(false);
+
+    // Restore console.error
+    console.error = originalConsoleError;
   });
 });
 
@@ -363,11 +370,18 @@ describe("fetchYoutubeVideoTitle", () => {
   });
 
   it("should handle fetch errors gracefully", async () => {
+    // Suppress error stack traces for this specific test
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
     const mockFetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
     global.fetch = mockFetch;
 
     const title = await fetchYoutubeVideoTitle("dQw4w9WgXcQ");
     expect(title).toBeNull();
+
+    // Restore console.error
+    console.error = originalConsoleError;
   });
 });
 


### PR DESCRIPTION
## Summary
- silence noisy YouTube utility tests by mocking console error output during failure scenarios
- wrap hook integration tests in act/unmount helpers to prevent React act warnings and align expectations
- include selectedRun ID in memo dependencies to satisfy linting

## Testing
- pnpm format
- pnpm fix
- pnpm tsc --noEmit
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c2919ab888326ab9d6c4b05a6732d)