### PR TITLE
Remove slide re-extraction support

### DIFF
--- a/components/analyze/slides-panel.test.tsx
+++ b/components/analyze/slides-panel.test.tsx
@@ -66,7 +66,7 @@ describe("SlidesPanel Auto-Trigger Extraction", () => {
     const calls = mockFetch.mock.calls;
     const postCall = calls.find((call) => call[1]?.method === "POST");
     expect(postCall).toBeDefined();
-    expect(postCall?.[0]).toBe(`/api/video/${mockVideoId}/slides?force=true`);
+    expect(postCall?.[0]).toBe(`/api/video/${mockVideoId}/slides`);
     expect(postCall?.[1]?.method).toBe("POST");
   });
 

--- a/components/analyze/slides-panel.tsx
+++ b/components/analyze/slides-panel.tsx
@@ -168,7 +168,7 @@ export function SlidesPanel({ videoId }: SlidesPanelProps) {
     }));
 
     try {
-      const response = await fetch(`/api/video/${videoId}/slides?force=true`, {
+      const response = await fetch(`/api/video/${videoId}/slides`, {
         method: "POST",
       });
 
@@ -285,15 +285,6 @@ export function SlidesPanel({ videoId }: SlidesPanelProps) {
       slides={slidesState.slides}
       feedbackMap={feedbackMap}
       onSubmitFeedback={submitFeedback}
-      onReExtract={() => {
-        setSlidesState((prev) => ({
-          ...prev,
-          slides: [],
-          progress: 0,
-          message: "",
-        }));
-        startExtraction();
-      }}
     />
   );
 }
@@ -414,13 +405,11 @@ function CompletedState({
   slides,
   feedbackMap,
   onSubmitFeedback,
-  onReExtract,
 }: {
   slidesCount: number;
   slides: SlideData[];
   feedbackMap: Map<number, SlideFeedbackData>;
   onSubmitFeedback: (feedback: SlideFeedbackData) => Promise<void>;
-  onReExtract: () => void;
 }) {
   return (
     <Card>
@@ -430,10 +419,6 @@ function CompletedState({
             <ImageIcon className="h-5 w-5" />
             Slides ({slidesCount})
           </span>
-
-          <Button variant="outline" size="sm" onClick={onReExtract}>
-            Re-extract
-          </Button>
         </CardTitle>
       </CardHeader>
 


### PR DESCRIPTION
### Motivation
- The UI no longer exposes a manual "Re-extract" action, so the backend "force" re-extraction flow and associated client wiring are unused and should be removed to simplify logic.
- Removing the unused code reduces UI clutter and avoids an unused query parameter on the extraction endpoint.

### Description
- Removed the `Re-extract` button and `onReExtract` wiring from `components/analyze/slides-panel.tsx` and simplified the completed-state rendering to drop the re-extract handler.
- Changed the client POST call to start extraction from `/api/video/{videoId}/slides?force=true` to `/api/video/{videoId}/slides` and updated `components/analyze/slides-panel.test.tsx` accordingly.
- Removed parsing of the `force` query param and the `force` branch in `app/api/video/[videoId]/slides/route.ts`, keeping only the retry-on-failed cleanup behavior and returning conflicts for completed/in-progress runs.
- Minor cleanup: renamed unused `request` param to `_request` in the POST handler and applied formatting/type fixes.

### Testing
- Ran `pnpm next typegen` and types were generated successfully.
- Ran `pnpm format` and code was formatted with no remaining issues.
- Ran `pnpm fix` (biome) and lint suggestions were applied or addressed.
- Ran `pnpm tsc --noEmit` and TypeScript checked successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694741fa9e7483268519cb915a34751f)