### PR TITLE
Add reusable video_id column helper

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -69,13 +69,16 @@ export const videos = pgTable(
   (table) => [index("videos_channel_id_idx").on(table.channelId)],
 );
 
+const videoIdColumn = () =>
+  varchar("video_id", { length: 32 })
+    .notNull()
+    .references(() => videos.videoId, { onDelete: "cascade" });
+
 export const scrapTranscriptV1 = pgTable(
   "scrap_transcript_v1",
   {
     id: serial("id").primaryKey(),
-    videoId: varchar("video_id", { length: 32 })
-      .notNull()
-      .references(() => videos.videoId, { onDelete: "cascade" }),
+    videoId: videoIdColumn(),
     channelId: varchar("channel_id", { length: 64 })
       .notNull()
       .references(() => channels.channelId, { onDelete: "cascade" }),
@@ -96,10 +99,7 @@ export type ScrapedTranscript = typeof scrapTranscriptV1.$inferSelect;
 export type NewScrapedTranscript = typeof scrapTranscriptV1.$inferInsert;
 
 export const videoAnalysisRuns = pgTable("video_analysis_runs", {
-  videoId: varchar("video_id", { length: 32 })
-    .notNull()
-    .primaryKey()
-    .references(() => videos.videoId, { onDelete: "cascade" }),
+  videoId: videoIdColumn().primaryKey(),
   result: jsonb("result").$type<Record<string, unknown>>(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
@@ -110,10 +110,7 @@ export type NewVideoAnalysisRun = typeof videoAnalysisRuns.$inferInsert;
 export const videoAnalysisWorkflowIds = pgTable(
   "video_analysis_workflow_ids",
   {
-    videoId: varchar("video_id", { length: 32 })
-      .notNull()
-      .primaryKey()
-      .references(() => videos.videoId, { onDelete: "cascade" }),
+    videoId: videoIdColumn().primaryKey(),
     workflowId: varchar("workflow_id", { length: 100 }).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
@@ -135,9 +132,7 @@ export const videoSlideExtractions = pgTable(
   "video_slide_extractions",
   {
     id: serial("id").primaryKey(),
-    videoId: varchar("video_id", { length: 32 })
-      .notNull()
-      .references(() => videos.videoId, { onDelete: "cascade" }),
+    videoId: videoIdColumn(),
     status: extractionStatusEnum("status").notNull().default("pending"),
     runId: varchar("run_id", { length: 100 }), // Workflow run ID for resumption
     totalSlides: integer("total_slides"),
@@ -156,9 +151,7 @@ export const videoSlides = pgTable(
   "video_slides",
   {
     id: serial("id").primaryKey(),
-    videoId: varchar("video_id", { length: 32 })
-      .notNull()
-      .references(() => videos.videoId, { onDelete: "cascade" }),
+    videoId: videoIdColumn(),
     slideNumber: integer("slide_index").notNull(),
 
     // Timing
@@ -208,9 +201,7 @@ export const slideFeedback = pgTable(
   "slide_feedback",
   {
     id: serial("id").primaryKey(),
-    videoId: varchar("video_id", { length: 32 })
-      .notNull()
-      .references(() => videos.videoId, { onDelete: "cascade" }),
+    videoId: videoIdColumn(),
     slideNumber: integer("slide_index").notNull(),
 
     // First frame validation


### PR DESCRIPTION
### Motivation

- Reduce repeated verbose Drizzle column definitions for the `video_id` foreign key across multiple tables.
- Make schema definitions more concise and less error-prone by centralizing the common column pattern.

### Description

- Add a shared helper `videoIdColumn` in `db/schema.ts` that returns `varchar("video_id", { length: 32 }).notNull().references(() => videos.videoId, { onDelete: "cascade" })`.
- Replace repeated `videoId` field definitions with `videoIdColumn()` in the video-related tables: `scrap_transcript_v1`, `video_analysis_runs`, `video_analysis_workflow_ids`, `video_slide_extractions`, `video_slides`, and `slide_feedback`.
- Keep the original `videos` and `channels` table definitions unchanged.

### Testing

- Ran the test suite with `pnpm test` (Vitest) and all tests passed: `122` tests succeeded.
- Ran TypeScript check with `pnpm tsc --noEmit` and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694804b4a38083269c73645cb8c8e659)