### PR TITLE
Replace slides numeric progress with step-based indicator

### DIFF
--- a/components/ui/step-indicator.tsx
+++ b/components/ui/step-indicator.tsx
@@ -1,0 +1,34 @@
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface StepIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  currentStep: number;
+  totalSteps: number;
+  message: string;
+}
+
+function StepIndicator({
+  currentStep,
+  totalSteps,
+  message,
+  className,
+  ...props
+}: StepIndicatorProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <span className="font-medium text-foreground">
+        Step {currentStep}/{totalSteps}
+      </span>
+      <span className="text-muted-foreground">:</span>
+      <span>{message}</span>
+    </div>
+  );
+}
+
+export { StepIndicator };

--- a/lib/slides-types.ts
+++ b/lib/slides-types.ts
@@ -54,7 +54,13 @@ export type VideoManifest = z.infer<typeof VideoManifestSchema>;
 // ============================================================================
 
 export type SlideStreamEvent =
-  | { type: "progress"; status: string; progress: number; message: string }
+  | {
+      type: "progress";
+      status: string;
+      step: number;
+      totalSteps: number;
+      message: string;
+    }
   | { type: "slide"; slide: SlideData }
   | { type: "complete"; totalSlides: number }
   | { type: "error"; message: string };
@@ -108,7 +114,8 @@ export interface JobUpdate {
 
 export interface SlidesState {
   status: "idle" | "loading" | "extracting" | "completed" | "error";
-  progress: number;
+  step: number;
+  totalSteps: number;
   message: string;
   error: string | null;
   slides: SlideData[];

--- a/workflows/extract-slides.ts
+++ b/workflows/extract-slides.ts
@@ -31,7 +31,8 @@ export async function extractSlidesWorkflow(videoId: string) {
       {
         type: "progress",
         status: "starting",
-        progress: 0,
+        step: 1,
+        totalSteps: 4,
         message: "Starting slide extraction...",
       },
       writable,
@@ -43,7 +44,8 @@ export async function extractSlidesWorkflow(videoId: string) {
       {
         type: "progress",
         status: "monitoring",
-        progress: 10,
+        step: 2,
+        totalSteps: 4,
         message: "Processing video on server...",
       },
       writable,
@@ -55,7 +57,8 @@ export async function extractSlidesWorkflow(videoId: string) {
       {
         type: "progress",
         status: "fetching",
-        progress: 80,
+        step: 3,
+        totalSteps: 4,
         message: "Fetching slide manifest...",
       },
       writable,
@@ -67,7 +70,8 @@ export async function extractSlidesWorkflow(videoId: string) {
       {
         type: "progress",
         status: "saving",
-        progress: 90,
+        step: 4,
+        totalSteps: 4,
         message: "Saving slides to database...",
       },
       writable,

--- a/workflows/steps/extract-slides/job-monitoring.ts
+++ b/workflows/steps/extract-slides/job-monitoring.ts
@@ -13,6 +13,24 @@ import { CONFIG } from "./config";
 // Step: Trigger extraction
 // ============================================================================
 
+const TOTAL_STEPS = 4;
+
+function resolveJobStep(status: JobStatus): number {
+  switch (status) {
+    case JobStatus.PENDING:
+      return 1;
+    case JobStatus.DOWNLOADING:
+    case JobStatus.EXTRACTING:
+      return 2;
+    case JobStatus.UPLOADING:
+    case JobStatus.COMPLETED:
+    case JobStatus.FAILED:
+      return 4;
+    default:
+      return 2;
+  }
+}
+
 export async function triggerExtraction(
   videoId: YouTubeVideoId,
 ): Promise<void> {
@@ -193,7 +211,8 @@ export async function checkJobStatus(
                 {
                   type: "progress",
                   status: jobUpdate.status,
-                  progress: jobUpdate.progress,
+                  step: resolveJobStep(jobUpdate.status),
+                  totalSteps: TOTAL_STEPS,
                   message: jobUpdate.message,
                 },
                 writable,


### PR DESCRIPTION
### Motivation

- Replace the arbitrary 0-100% numeric progress for slide extraction with a discrete step-based indicator for clearer, more honest UX.
- Provide explicit extraction phases (init, processing, manifest, saving) so users know the current phase instead of an artificial percentage.
- Simplify backend → frontend progress contract to `step`/`totalSteps` while preserving informative status messages.
- Keep slide preview and SSE streaming behavior unchanged while migrating the progress model.

### Description

- Updated the stream event and UI state types in `lib/slides-types.ts` by replacing `progress: number` with `step: number` and `totalSteps: number` and updating `SlideStreamEvent` to emit step-based progress.
- Emitted step events from the workflow in `workflows/extract-slides.ts` for the main phases (`step: 1..4`, `totalSteps: 4`) with descriptive messages.
- Added a `resolveJobStep` mapper and `TOTAL_STEPS` constant in `workflows/steps/extract-slides/job-monitoring.ts` to map external job statuses to step numbers and emit `step`/`totalSteps` during job monitoring.
- Replaced the numeric progress bar in the UI by adding a reusable `components/ui/step-indicator.tsx` and switching `components/analyze/slides-panel.tsx` to use `step`/`totalSteps` from SSE events and display the step indicator instead of the `Progress` component.

### Testing

- Ran formatting and lint fixes with `pnpm format` and `pnpm fix` and generated route types with `pnpm next typegen` successfully.
- Type-checking with `pnpm tsc --noEmit` completed without errors.
- Unit/component tests via `pnpm test` passed (all test suites green — 122 tests passed in this run).
- Attempted an automated Playwright UI capture to verify the step indicator, but the run failed to connect to the dev server due to a missing `NEXT_PUBLIC_STACK_PROJECT_ID` (Next.js returned 500), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694823bb927c83268d094de434b3eec5)