### PR TITLE
Move slide grid to top-level tab

### DIFF
--- a/components/analyze/analyze-tabs.tsx
+++ b/components/analyze/analyze-tabs.tsx
@@ -14,6 +14,7 @@ const parseAsPresence = createParser<boolean>({
 const tabQueryConfig = {
   analyze: parseAsPresence,
   slides: parseAsPresence,
+  slidesGrid: parseAsPresence,
 };
 
 type AnalyzeTabsProps = {
@@ -22,15 +23,24 @@ type AnalyzeTabsProps = {
 
 export function AnalyzeTabs({ videoId }: AnalyzeTabsProps) {
   const [queryState, setQueryState] = useQueryStates(tabQueryConfig);
-  const activeTab = queryState.slides ? "slides" : "analyze";
+  const activeTab = queryState.slidesGrid
+    ? "slides-grid"
+    : queryState.slides
+      ? "slides"
+      : "analyze";
 
   const handleTabChange = (value: string) => {
-    if (value === "slides") {
-      void setQueryState({ slides: true, analyze: null });
+    if (value === "slides-grid") {
+      void setQueryState({ slidesGrid: true, slides: null, analyze: null });
       return;
     }
 
-    void setQueryState({ analyze: true, slides: null });
+    if (value === "slides") {
+      void setQueryState({ slides: true, slidesGrid: null, analyze: null });
+      return;
+    }
+
+    void setQueryState({ analyze: true, slides: null, slidesGrid: null });
   };
 
   return (
@@ -41,7 +51,8 @@ export function AnalyzeTabs({ videoId }: AnalyzeTabsProps) {
     >
       <TabsList>
         <TabsTrigger value="analyze">Analysis</TabsTrigger>
-        <TabsTrigger value="slides">Slides</TabsTrigger>
+        <TabsTrigger value="slides">Slide Curation</TabsTrigger>
+        <TabsTrigger value="slides-grid">Slides Grid</TabsTrigger>
       </TabsList>
 
       <TabsContent value="analyze">
@@ -49,7 +60,11 @@ export function AnalyzeTabs({ videoId }: AnalyzeTabsProps) {
       </TabsContent>
 
       <TabsContent value="slides">
-        <SlidesPanel videoId={videoId} />
+        <SlidesPanel videoId={videoId} view="curation" />
+      </TabsContent>
+
+      <TabsContent value="slides-grid">
+        <SlidesPanel videoId={videoId} view="grid" />
       </TabsContent>
     </Tabs>
   );

--- a/components/analyze/slide-grid-tab.tsx
+++ b/components/analyze/slide-grid-tab.tsx
@@ -23,7 +23,6 @@ import { ZoomDialog } from "./zoom-dialog";
 // ============================================================================
 
 interface SlideGridTabProps {
-  videoId: string;
   slides: SlideData[];
   feedbackMap: Map<number, SlideFeedbackData>;
 }
@@ -32,11 +31,7 @@ interface SlideGridTabProps {
 // Main Component
 // ============================================================================
 
-export function SlideGridTab({
-  videoId: _videoId,
-  slides,
-  feedbackMap,
-}: SlideGridTabProps) {
+export function SlideGridTab({ slides, feedbackMap }: SlideGridTabProps) {
   const [slidesConfirmed, setSlidesConfirmed] = useState(false);
 
   // Compute picked slides from the slides and feedback

--- a/components/analyze/slides-panel.test.tsx
+++ b/components/analyze/slides-panel.test.tsx
@@ -65,14 +65,16 @@ describe("SlidesPanel Auto-Trigger Extraction", () => {
     });
 
     // Verify that the POST request was made to start extraction
-    const mockFetch = fetch as unknown as {
-      mock: { calls: Array<[string, RequestInit?]> };
-    };
-    const calls = mockFetch.mock.calls;
-    const postCall = calls.find((call) => call[1]?.method === "POST");
-    expect(postCall).toBeDefined();
-    expect(postCall?.[0]).toBe(`/api/video/${mockVideoId}/slides`);
-    expect(postCall?.[1]?.method).toBe("POST");
+    await waitFor(() => {
+      const mockFetch = fetch as unknown as {
+        mock: { calls: Array<[string, RequestInit?]> };
+      };
+      const calls = mockFetch.mock.calls;
+      const postCall = calls.find((call) => call[1]?.method === "POST");
+      expect(postCall).toBeDefined();
+      expect(postCall?.[0]).toBe(`/api/video/${mockVideoId}/slides`);
+      expect(postCall?.[1]?.method).toBe("POST");
+    });
   });
 
   it("should not auto-trigger extraction when slides already exist", async () => {


### PR DESCRIPTION
### Motivation
- The UI should present the slide grid as a top-level tab alongside Analysis and Slide Curation for easier access.
- The existing Slides tab should be clarified as the Slide Curation view (i.e. the curated/selection UI).

### Description
- Promote the Slides Grid to a top-level tab by adding a `slides-grid` tab in `AnalyzeTabs` and a `slidesGrid` query state key, and rename the existing tab to `Slide Curation`.
- Simplify `SlidesPanel` to accept a `view?: 'curation' | 'grid'` prop and render either the curation (`SlideGrid`) or grid (`SlideGridTab`) view instead of managing internal subtabs with `nuqs`.
- Update `SlideGridTab` to remove an unused `videoId` prop and streamline its usage, and remove the internal `slidesTab` query parsing from `slides-panel`.
- Fix the `SlidesPanel` test to wait for the extraction `POST` request and adjust expectations accordingly.

### Testing
- Ran `pnpm format` which completed successfully.
- Ran `pnpm fix` which completed successfully.
- Ran `pnpm test` and all automated tests passed (`122` tests passed).
- Ran `pnpm next typegen` and `pnpm tsc --noEmit` successfully, and attempted `pnpm build` which failed due to `next/font` being unable to fetch Geist fonts from Google Fonts in this environment (network/TLS issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483048b5a88326a54a62d46272bf86)