### PR TITLE
Add individual copy buttons to each section in the analysis

### DIFF
--- a/lib/analysis-format.test.ts
+++ b/lib/analysis-format.test.ts
@@ -4,6 +4,7 @@ import {
   analysisToMarkdown,
   contentToMarkdown,
   formatSectionTitle,
+  sectionToMarkdown,
 } from "./analysis-format";
 
 describe("formatSectionTitle", () => {
@@ -143,5 +144,40 @@ describe("analysisToMarkdown", () => {
     expect(result).toContain("- item 1");
     expect(result).toContain("## Details");
     expect(result).toContain("**key**: value");
+  });
+});
+
+describe("sectionToMarkdown", () => {
+  it("should convert a section with string content to markdown", () => {
+    const result = sectionToMarkdown("tldr", "This is a summary");
+    expect(result).toBe("## Tldr\n\nThis is a summary");
+  });
+
+  it("should convert a section with array content to markdown", () => {
+    const result = sectionToMarkdown("key_takeaways", ["Point 1", "Point 2"]);
+    expect(result).toContain("## Key Takeaways");
+    expect(result).toContain("- Point 1");
+    expect(result).toContain("- Point 2");
+  });
+
+  it("should convert a section with object content to markdown", () => {
+    const result = sectionToMarkdown("metadata", {
+      title: "Test",
+      duration: "10:00",
+    });
+    expect(result).toContain("## Metadata");
+    expect(result).toContain("**title**: Test");
+    expect(result).toContain("**duration**: 10:00");
+  });
+
+  it("should handle empty content", () => {
+    const result = sectionToMarkdown("empty_section", null);
+    expect(result).toContain("## Empty Section");
+    expect(result).toContain("_No content_");
+  });
+
+  it("should format section title correctly", () => {
+    const result = sectionToMarkdown("my_custom_section", "content");
+    expect(result).toContain("## My Custom Section");
   });
 });

--- a/lib/analysis-format.ts
+++ b/lib/analysis-format.ts
@@ -90,3 +90,13 @@ export function analysisToMarkdown(analysis: Record<string, unknown>): string {
 
   return markdown.trim();
 }
+
+/**
+ * Converts a single section to markdown format.
+ * Includes the section title as an h2 header.
+ */
+export function sectionToMarkdown(title: string, content: unknown): string {
+  let markdown = `## ${formatSectionTitle(title)}\n\n`;
+  markdown += contentToMarkdown(content);
+  return markdown.trim();
+}


### PR DESCRIPTION
Add individual copy buttons to each section in the analysis panel to allow users to copy specific parts of the analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b856609-d07e-476c-9b13-dfdbe6938a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b856609-d07e-476c-9b13-dfdbe6938a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

