### PR TITLE
Self-host Geist fonts via localFont to avoid build-time Google Fonts fetches

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import { StackProvider, StackTheme } from "@stackframe/stack";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import localFont from "next/font/local";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type React from "react";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -8,14 +8,28 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { stackClientApp } from "../stack/client";
 import "./globals.css";
 
-const geistSans = Geist({
+const geistSans = localFont({
+  src: [
+    {
+      path: "../node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2",
+      style: "normal",
+      weight: "100 900",
+    },
+  ],
   variable: "--font-geist-sans",
-  subsets: ["latin"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
+const geistMono = localFont({
+  src: [
+    {
+      path: "../node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2",
+      style: "normal",
+      weight: "100 900",
+    },
+  ],
   variable: "--font-geist-mono",
-  subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "effect": "^3.19.12",
     "embla-carousel-react": "latest",
     "eventsource-parser": "^3.0.6",
+    "geist": "^1.5.1",
     "happy-dom": "latest",
     "input-otp": "latest",
     "lucide-react": "^0.454.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       eventsource-parser:
         specifier: ^3.0.6
         version: 3.0.6
+      geist:
+        specifier: ^1.5.1
+        version: 1.5.1(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       happy-dom:
         specifier: latest
         version: 20.0.11
@@ -5814,6 +5817,11 @@ packages:
     resolution: {integrity: sha512-vn7TtQ3b9VMJtVXsyWtQQl1fyBVFhQy7UvJF96kPuuJ0or5THH496AD3eUyaDD11+EqCxH9t6V+EP9soZQk4YQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  geist@1.5.1:
+    resolution: {integrity: sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   gel@2.2.0:
     resolution: {integrity: sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==}
@@ -16314,6 +16322,10 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  geist@1.5.1(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)):
+    dependencies:
+      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   gel@2.2.0:
     dependencies:


### PR DESCRIPTION
### Motivation

- Prevent `next/font/google` from fetching fonts at build time which can fail in locked-down CI or sandboxes.
- Make the production build deterministic by self-hosting Geist font assets.

### Description

- Added the `geist` package and referenced its variable font files instead of using `next/font/google`.
- Replaced `Geist`/`Geist_Mono` imports with `localFont` and pointed `app/layout.tsx` to `node_modules/geist/dist/fonts/*-Variable.woff2` files.
- Corrected font file paths to match the package files and preserved the CSS variable usage (`--font-geist-sans`, `--font-geist-mono`).

### Testing

- Ran `pnpm format`, `pnpm fix`, and `pnpm next typegen` and they completed successfully.
- Ran `pnpm tsc --noEmit` and type checking passed without errors.
- Executed `pnpm test` (Vitest) and all tests passed (`122` tests total).
- Ran `pnpm build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948393264148326958b5aef3ec717df)