### PR TITLE
Remove duplicate preview and add "Unpick all frames" button

### DIFF
--- a/components/analyze/slide-card.tsx
+++ b/components/analyze/slide-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Copy, ImageIcon, ThumbsDown, ThumbsUp, ZoomIn } from "lucide-react";
+import { ImageIcon, ThumbsDown, ThumbsUp, ZoomIn } from "lucide-react";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -15,10 +15,6 @@ import { ZoomDialog } from "./zoom-dialog";
 interface FrameCardProps {
   label: "First" | "Last";
   imageUrl: string | null;
-  isDuplicate: boolean;
-  duplicateOfSlideNumber: number | null;
-  duplicateOfFramePosition: string | null;
-  allSlides: SlideData[];
   onZoom: () => void;
   isPicked: boolean;
   onPickedChange: (picked: boolean) => void;
@@ -29,28 +25,12 @@ interface FrameCardProps {
 function FrameCard({
   label,
   imageUrl,
-  isDuplicate,
-  duplicateOfSlideNumber,
-  duplicateOfFramePosition,
-  allSlides,
   onZoom,
   isPicked,
   onPickedChange,
   hasUsefulContent,
   onUsefulContentChange,
 }: FrameCardProps) {
-  // Find duplicate slide if exists
-  const duplicateSlide =
-    isDuplicate && duplicateOfSlideNumber !== null
-      ? allSlides.find((s) => s.slideNumber === duplicateOfSlideNumber)
-      : null;
-
-  const duplicateImageUrl = duplicateSlide
-    ? label === "First"
-      ? duplicateSlide.firstFrameImageUrl
-      : duplicateSlide.lastFrameImageUrl
-    : null;
-
   return (
     <div className="flex flex-col gap-3">
       {/* Frame header with checkbox */}
@@ -95,26 +75,6 @@ function FrameCard({
             {label}
           </div>
         </button>
-
-        {/* Mini duplicate preview */}
-        {isDuplicate && duplicateImageUrl && (
-          <div className="mt-2 flex items-center gap-2">
-            <Copy className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-            <div className="relative w-16 rounded overflow-hidden border">
-              <Image
-                src={duplicateImageUrl || "/placeholder.svg"}
-                alt={`Duplicate of slide ${duplicateOfSlideNumber}`}
-                width={64}
-                height={36}
-                className="w-full h-auto object-contain"
-              />
-            </div>
-            <span className="text-xs text-muted-foreground">
-              #{duplicateOfSlideNumber}
-              {duplicateOfFramePosition ? `-${duplicateOfFramePosition}` : ""}
-            </span>
-          </div>
-        )}
       </div>
 
       <div className="flex items-center justify-between gap-2 rounded-md border bg-muted/30 p-3">
@@ -154,14 +114,12 @@ function FrameCard({
 
 interface SlideCardProps {
   slide: SlideData;
-  allSlides: SlideData[];
   initialFeedback?: SlideFeedbackData;
   onSubmitFeedback: (feedback: SlideFeedbackData) => Promise<void>;
 }
 
 export function SlideCard({
   slide,
-  allSlides,
   initialFeedback,
   onSubmitFeedback,
 }: SlideCardProps) {
@@ -240,10 +198,6 @@ export function SlideCard({
           <FrameCard
             label="First"
             imageUrl={slide.firstFrameImageUrl}
-            isDuplicate={slide.firstFrameIsDuplicate}
-            duplicateOfSlideNumber={slide.firstFrameDuplicateOfSlideNumber}
-            duplicateOfFramePosition={slide.firstFrameDuplicateOfFramePosition}
-            allSlides={allSlides}
             onZoom={() => handleZoom("first")}
             isPicked={feedback.isFirstFramePicked}
             onPickedChange={(picked) =>
@@ -257,10 +211,6 @@ export function SlideCard({
           <FrameCard
             label="Last"
             imageUrl={slide.lastFrameImageUrl}
-            isDuplicate={slide.lastFrameIsDuplicate}
-            duplicateOfSlideNumber={slide.lastFrameDuplicateOfSlideNumber}
-            duplicateOfFramePosition={slide.lastFrameDuplicateOfFramePosition}
-            allSlides={allSlides}
             onZoom={() => handleZoom("last")}
             isPicked={feedback.isLastFramePicked}
             onPickedChange={(picked) =>


### PR DESCRIPTION
### Motivation

- Simplify the slide curation UI by removing a confusing duplicate-preview indicator from frame cards.
- Provide a bulk action to clear all picked frames so users can quickly reset selections.
- Reduce duplicated props and coupling between `SlideCard` and frame preview logic.
- Fix a lint issue caused by duplicate object keys in the bulk-update code.

### Description

- Removed duplicate-preview UI and related props/lookup logic from `FrameCard` and `SlideCard` in `components/analyze/slide-card.tsx`.
- Added an "Unpick all frames" button and handler to `SlidesPanel` that bulk-updates feedback to unpick both first and last frames for all slides in `components/analyze/slides-panel.tsx`.
- Introduced local state flags `isUnpickingAll` and computed `hasPickedFrames` to drive the button state and avoid redundant operations.
- Cleaned up object merging to avoid duplicate object keys and addressed the corresponding lint warning.

### Testing

- Ran `pnpm format` and `pnpm fix` and they completed successfully.
- Ran `pnpm test` and the test suite passed (all tests succeeded).
- Ran `pnpm next typegen` and `pnpm tsc --noEmit` and both completed successfully.
- Ran `pnpm build` (Next.js build) and it compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694876cff96c8326be9575ca7d89400c)