### PR TITLE
Show picked/total slides count in curation panel

### DIFF
--- a/components/analyze/slides-panel.test.tsx
+++ b/components/analyze/slides-panel.test.tsx
@@ -117,7 +117,7 @@ describe("SlidesPanel Auto-Trigger Extraction", () => {
 
     // Should show completed state, not trigger extraction
     await waitFor(() => {
-      expect(screen.getByText("Slides (1)")).toBeInTheDocument();
+      expect(screen.getByText("Slides (1/1)")).toBeInTheDocument();
     });
 
     // Verify that no POST request was made

--- a/components/analyze/slides-panel.tsx
+++ b/components/analyze/slides-panel.tsx
@@ -219,6 +219,18 @@ export function SlidesPanel({ videoId, view = "curation" }: SlidesPanelProps) {
     [feedbackMap, slidesState.slides],
   );
 
+  const pickedSlidesCount = useMemo(
+    () =>
+      slidesState.slides.filter((slide) => {
+        const feedback = feedbackMap.get(slide.slideNumber);
+        const isFirstPicked = feedback?.isFirstFramePicked ?? true;
+        const isLastPicked = feedback?.isLastFramePicked ?? false;
+
+        return isFirstPicked || isLastPicked;
+      }).length,
+    [feedbackMap, slidesState.slides],
+  );
+
   const startExtraction = useCallback(async () => {
     // Set state to extracting
     setSlidesState((prev) => ({
@@ -351,6 +363,7 @@ export function SlidesPanel({ videoId, view = "curation" }: SlidesPanelProps) {
   return (
     <CompletedState
       slidesCount={slidesState.slides.length}
+      pickedSlidesCount={pickedSlidesCount}
       slides={slidesState.slides}
       feedbackMap={feedbackMap}
       onSubmitFeedback={submitFeedback}
@@ -448,6 +461,7 @@ function ErrorState({
 
 function CompletedState({
   slidesCount,
+  pickedSlidesCount,
   slides,
   feedbackMap,
   onSubmitFeedback,
@@ -457,6 +471,7 @@ function CompletedState({
   hasPickedFrames,
 }: {
   slidesCount: number;
+  pickedSlidesCount: number;
   slides: SlideData[];
   feedbackMap: Map<number, SlideFeedbackData>;
   onSubmitFeedback: (feedback: SlideFeedbackData) => Promise<void>;
@@ -465,13 +480,18 @@ function CompletedState({
   isUnpickingAll: boolean;
   hasPickedFrames: boolean;
 }) {
+  const slidesLabel =
+    view === "curation"
+      ? `Slides (${pickedSlidesCount}/${slidesCount})`
+      : `Slides (${slidesCount})`;
+
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center justify-between">
           <span className="flex items-center gap-2">
             <ImageIcon className="h-5 w-5" />
-            Slides ({slidesCount})
+            {slidesLabel}
           </span>
           {view === "curation" && (
             <Button


### PR DESCRIPTION
### Motivation
- Make the slides curation header more informative by showing how many slides are currently selected out of the total. 
- Help users understand selection progress at a glance while curating slides. 

### Description
- Compute `pickedSlidesCount` from `slidesState.slides` and `feedbackMap` using `useMemo` in `components/analyze/slides-panel.tsx`. 
- Pass `pickedSlidesCount` into the completed view and render `Slides (picked/total)` when `view === "curation"`, otherwise keep `Slides (total)`. 
- Update the component test expectation in `components/analyze/slides-panel.test.tsx` to assert the new label format `Slides (1/1)`. 

### Testing
- Ran `pnpm next typegen`, `pnpm format`, and `pnpm fix` to regenerate types and format the code successfully. 
- Ran `pnpm test` and all unit tests passed (including updated slides panel tests). 
- Ran `pnpm tsc --noEmit` and type checking completed without errors. 
- Ran `pnpm build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69487c2607548326a87ae101872ac647)