### PR TITLE
Database default frame setting

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -213,7 +213,7 @@ export const slideFeedback = pgTable(
 
     // Frame selection - whether individual frames are picked for export
     isFirstFramePicked: boolean("is_first_frame_picked")
-      .default(true)
+      .default(false)
       .notNull(),
     isLastFramePicked: boolean("is_last_frame_picked").default(false).notNull(),
 


### PR DESCRIPTION
Update `isFirstFramePicked` default to `false` to ensure all frames are unpicked by default.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbdd4d13-21da-4bc6-bb47-1298d714e258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbdd4d13-21da-4bc6-bb47-1298d714e258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

