### PR TITLE
Add hover title to processed video links

### DIFF
--- a/components/processed-videos-list.tsx
+++ b/components/processed-videos-list.tsx
@@ -155,6 +155,7 @@ export const columns: ColumnDef<VideoData>[] = [
     cell: ({ row }) => (
       <Link
         href={`/video/youtube/${row.original.videoId}`}
+        title={row.original.videoData?.title || "Untitled Video"}
         className="line-clamp-2 hover:text-primary font-medium"
       >
         {row.original.videoData?.title || "Untitled Video"}


### PR DESCRIPTION
### Motivation
- Video titles in the processed videos table are truncated with `line-clamp-2`, preventing users from seeing long titles at a glance.
- Showing the full title on hover improves discoverability and usability for long video names.
- This is a small, non-invasive UI/accessibility improvement that requires only a markup change.

### Description
- Added a `title` attribute to the processed video `Link` rendered in `components/processed-videos-list.tsx` so the full title is visible on hover.
- The `title` falls back to `Untitled Video` when a title is not available.
- No other UI behavior or layout changes were made.

### Testing
- Ran `pnpm format` and `pnpm fix`, both completed successfully.
- Ran `pnpm test`, and the test suite passed (`127` tests succeeded).
- Ran `pnpm next typegen` and `pnpm tsc --noEmit`, both completed successfully.
- Ran `pnpm build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948d237ddac83269f1b9757709874c1)