### PR TITLE
Refactor video analysis workflow structure

### DIFF
--- a/components/analyze/analyze-shell.tsx
+++ b/components/analyze/analyze-shell.tsx
@@ -97,11 +97,11 @@ export function AnalyzeShell({
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const isDark = resolvedTheme === "dark";
-  // Hide slide-analysis tab - it's now part of super analysis workflow
-  // The tab is kept in the tabs array for potential debug access
+  // Hide slide-analysis tab until super analysis is complete (for reviewing slide extraction results)
+  // Hide super-analysis from tab bar (accessed via slides panel button)
   const visibleTabs = tabs.filter((tab) => {
     if (tab.id === "super-analysis") return false;
-    if (tab.id === "slide-analysis") return false;
+    if (tab.id === "slide-analysis") return hasSuperAnalysis;
     return true;
   });
 

--- a/components/analyze/analyze-shell.tsx
+++ b/components/analyze/analyze-shell.tsx
@@ -97,9 +97,11 @@ export function AnalyzeShell({
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const isDark = resolvedTheme === "dark";
+  // Hide slide-analysis tab - it's now part of super analysis workflow
+  // The tab is kept in the tabs array for potential debug access
   const visibleTabs = tabs.filter((tab) => {
     if (tab.id === "super-analysis") return false;
-    if (tab.id === "slide-analysis") return hasSlideAnalysis;
+    if (tab.id === "slide-analysis") return false;
     return true;
   });
 

--- a/components/analyze/slide-card.tsx
+++ b/components/analyze/slide-card.tsx
@@ -19,6 +19,7 @@ interface FrameCardProps {
   onZoom: () => void;
   isPicked: boolean;
   onPickedChange: (picked: boolean) => void;
+  disabled?: boolean;
 }
 
 function FrameCard({
@@ -27,23 +28,28 @@ function FrameCard({
   onZoom,
   isPicked,
   onPickedChange,
+  disabled = false,
 }: FrameCardProps) {
   return (
     <div className="flex flex-col gap-3">
       {/* Frame header with prominent checkbox */}
       <label
         className={cn(
-          "flex items-center gap-3 p-3 rounded-lg border-2 cursor-pointer transition-all",
+          "flex items-center gap-3 p-3 rounded-lg border-2 transition-all",
+          disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
           isPicked
             ? "bg-primary/10 border-primary shadow-sm"
-            : "bg-muted/30 border-muted hover:border-primary/50 hover:bg-primary/5",
+            : disabled
+              ? "bg-muted/30 border-muted"
+              : "bg-muted/30 border-muted hover:border-primary/50 hover:bg-primary/5",
         )}
       >
         <input
           type="checkbox"
           checked={isPicked}
           onChange={(e) => onPickedChange(e.target.checked)}
-          className="h-5 w-5 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+          disabled={disabled}
+          className="h-5 w-5 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
         />
         <span className="text-base font-semibold">Pick {label} Frame</span>
       </label>
@@ -93,6 +99,7 @@ interface SlideCardProps {
   initialFeedback?: SlideFeedbackData;
   onSubmitFeedback: (feedback: SlideFeedbackData) => Promise<void>;
   showOnlyPickedFrames?: boolean;
+  disabled?: boolean;
 }
 
 export function SlideCard({
@@ -100,6 +107,7 @@ export function SlideCard({
   initialFeedback,
   onSubmitFeedback,
   showOnlyPickedFrames = false,
+  disabled = false,
 }: SlideCardProps) {
   const [zoomOpen, setZoomOpen] = useState(false);
   const [zoomFrame, setZoomFrame] = useState<"first" | "last">("first");
@@ -194,6 +202,7 @@ export function SlideCard({
               onPickedChange={(picked) =>
                 updateField("isFirstFramePicked", picked)
               }
+              disabled={disabled}
             />
           )}
           {showLastFrame && (
@@ -205,6 +214,7 @@ export function SlideCard({
               onPickedChange={(picked) =>
                 updateField("isLastFramePicked", picked)
               }
+              disabled={disabled}
             />
           )}
         </div>
@@ -224,6 +234,7 @@ export function SlideCard({
                       : "ghost"
                   }
                   size="sm"
+                  disabled={disabled}
                   onClick={() =>
                     updateField(
                       "framesSameness",

--- a/lib/super-analysis-types.ts
+++ b/lib/super-analysis-types.ts
@@ -1,8 +1,27 @@
+export type SlideAnalysisStatus =
+  | "pending"
+  | "analyzing"
+  | "completed"
+  | "failed";
+
+export interface SlideAnalysisProgress {
+  slideNumber: number;
+  framePosition: "first" | "last";
+  status: SlideAnalysisStatus;
+  error?: string;
+}
+
 export type SuperAnalysisStreamEvent =
   | {
       type: "progress";
       phase: string;
       message: string;
+    }
+  | {
+      type: "slide_analysis_progress";
+      slides: SlideAnalysisProgress[];
+      completedCount: number;
+      totalCount: number;
     }
   | {
       type: "partial";

--- a/workflows/steps/super-analysis.ts
+++ b/workflows/steps/super-analysis.ts
@@ -1,15 +1,19 @@
 import { z } from "zod";
+import { analyzeSlide } from "@/ai/slide-analysis";
 import { streamSuperAnalysis } from "@/ai/super-analysis";
 import {
   getCompletedAnalysis,
   getCompletedSuperAnalysis,
   getSlideAnalysisResults,
+  getSlideFeedback,
   getVideoSlides,
   getVideoWithTranscript,
+  saveSlideAnalysisResult,
   saveSuperAnalysisResult,
 } from "@/db/queries";
 import { emit } from "@/lib/stream-utils";
 import type {
+  SlideAnalysisProgress,
   SuperAnalysisInputData,
   SuperAnalysisStreamEvent,
 } from "@/lib/super-analysis-types";
@@ -93,6 +97,173 @@ export async function getSuperAnalysisInputData(
 export async function checkExistingSuperAnalysis(videoId: string) {
   "use step";
   return await getCompletedSuperAnalysis(videoId);
+}
+
+// ============================================================================
+// Slide Analysis Types for Super Analysis
+// ============================================================================
+
+interface PickedSlideInfo {
+  slideNumber: number;
+  framePosition: "first" | "last";
+  imageUrl: string;
+  startTime: number;
+  endTime: number;
+  videoTitle: string;
+  transcriptContext: string;
+}
+
+// ============================================================================
+// Step: Get picked slides for super analysis
+// ============================================================================
+
+export async function getPickedSlidesForSuperAnalysis(
+  videoId: string,
+): Promise<PickedSlideInfo[]> {
+  "use step";
+
+  const videoData = await getVideoWithTranscript(videoId);
+  if (!videoData) {
+    throw new Error("Video not found or no transcript available");
+  }
+
+  const slides = await getVideoSlides(videoId);
+  if (slides.length === 0) {
+    throw new Error("No slides found for this video");
+  }
+
+  const feedback = await getSlideFeedback(videoId);
+  const feedbackMap = new Map(feedback.map((f) => [f.slideNumber, f]));
+
+  const transcriptSegments = validateTranscriptStructure(videoData.transcript);
+
+  const pickedSlides: PickedSlideInfo[] = [];
+
+  for (const slide of slides) {
+    const fb = feedbackMap.get(slide.slideNumber);
+    const isFirstPicked = fb?.isFirstFramePicked ?? false;
+    const isLastPicked = fb?.isLastFramePicked ?? false;
+
+    const transcriptContext = getTranscriptContextForSlide(
+      transcriptSegments,
+      slide.startTime,
+      slide.endTime,
+    );
+
+    if (isFirstPicked && slide.firstFrameImageUrl) {
+      pickedSlides.push({
+        slideNumber: slide.slideNumber,
+        framePosition: "first",
+        imageUrl: slide.firstFrameImageUrl,
+        startTime: slide.startTime,
+        endTime: slide.endTime,
+        videoTitle: videoData.title,
+        transcriptContext,
+      });
+    }
+
+    if (isLastPicked && slide.lastFrameImageUrl) {
+      pickedSlides.push({
+        slideNumber: slide.slideNumber,
+        framePosition: "last",
+        imageUrl: slide.lastFrameImageUrl,
+        startTime: slide.startTime,
+        endTime: slide.endTime,
+        videoTitle: videoData.title,
+        transcriptContext,
+      });
+    }
+  }
+
+  return pickedSlides;
+}
+
+function getTranscriptContextForSlide(
+  segments: Array<{ start: number; end: number; text: string }>,
+  startTime: number,
+  endTime: number,
+): string {
+  const bufferStart = Math.max(0, startTime - 10);
+  const bufferEnd = endTime + 10;
+
+  const relevantSegments = segments.filter(
+    (segment) => segment.end >= bufferStart && segment.start <= bufferEnd,
+  );
+
+  if (relevantSegments.length === 0) {
+    return "";
+  }
+
+  return relevantSegments.map((s) => s.text).join(" ");
+}
+
+// ============================================================================
+// Step: Run slide analysis for a single slide
+// ============================================================================
+
+export async function runSingleSlideAnalysis(
+  videoId: string,
+  slideInfo: PickedSlideInfo,
+): Promise<{
+  slideNumber: number;
+  framePosition: "first" | "last";
+  markdown: string;
+}> {
+  "use step";
+
+  const markdown = await analyzeSlide({
+    videoTitle: slideInfo.videoTitle,
+    slideNumber: slideInfo.slideNumber,
+    framePosition: slideInfo.framePosition,
+    imageUrl: slideInfo.imageUrl,
+    transcriptContext: slideInfo.transcriptContext || undefined,
+  });
+
+  await saveSlideAnalysisResult(
+    videoId,
+    slideInfo.slideNumber,
+    slideInfo.framePosition,
+    markdown,
+  );
+
+  return {
+    slideNumber: slideInfo.slideNumber,
+    framePosition: slideInfo.framePosition,
+    markdown,
+  };
+}
+
+// ============================================================================
+// Step: Check which slides already have analysis results
+// ============================================================================
+
+export async function getExistingSlideAnalysisResults(videoId: string) {
+  "use step";
+  return await getSlideAnalysisResults(videoId);
+}
+
+// ============================================================================
+// Helper: Create initial slide progress state
+// ============================================================================
+
+export function createInitialSlideProgress(
+  pickedSlides: PickedSlideInfo[],
+  existingResults: Array<{ slideNumber: number; framePosition: string }>,
+): SlideAnalysisProgress[] {
+  const existingSet = new Set(
+    existingResults.map((r) => `${r.slideNumber}-${r.framePosition}`),
+  );
+
+  return pickedSlides.map((slide) => {
+    const key = `${slide.slideNumber}-${slide.framePosition}`;
+    return {
+      slideNumber: slide.slideNumber,
+      framePosition: slide.framePosition,
+      status: existingSet.has(key)
+        ? ("completed" as const)
+        : ("pending" as const),
+    };
+  });
 }
 
 export async function runSuperAnalysisStep(

--- a/workflows/super-analysis.ts
+++ b/workflows/super-analysis.ts
@@ -1,9 +1,16 @@
 import { getWritable } from "workflow";
 import { emit } from "@/lib/stream-utils";
-import type { SuperAnalysisStreamEvent } from "@/lib/super-analysis-types";
+import type {
+  SlideAnalysisProgress,
+  SuperAnalysisStreamEvent,
+} from "@/lib/super-analysis-types";
 import {
   checkExistingSuperAnalysis,
+  createInitialSlideProgress,
+  getExistingSlideAnalysisResults,
+  getPickedSlidesForSuperAnalysis,
   getSuperAnalysisInputData,
+  runSingleSlideAnalysis,
   runSuperAnalysisStep,
   saveSuperAnalysisResultStep,
 } from "@/workflows/steps/super-analysis";
@@ -24,6 +31,145 @@ export async function superAnalysisWorkflow(videoId: string) {
       return { success: true, usedCache: true };
     }
 
+    // Phase 1: Load picked slides and check existing analysis results
+    await emit<SuperAnalysisStreamEvent>(
+      {
+        type: "progress",
+        phase: "loading",
+        message: "Loading selected slides...",
+      },
+      writable,
+    );
+
+    const pickedSlides = await getPickedSlidesForSuperAnalysis(videoId);
+
+    if (pickedSlides.length === 0) {
+      throw new Error(
+        "No slides selected for analysis. Please pick some slides first.",
+      );
+    }
+
+    const existingResults = await getExistingSlideAnalysisResults(videoId);
+    const slideProgress = createInitialSlideProgress(
+      pickedSlides,
+      existingResults,
+    );
+
+    // Count how many slides need to be analyzed
+    const slidesNeedingAnalysis = slideProgress.filter(
+      (s) => s.status === "pending",
+    );
+    const alreadyCompletedCount = slideProgress.filter(
+      (s) => s.status === "completed",
+    ).length;
+
+    // Emit initial slide analysis progress
+    await emit<SuperAnalysisStreamEvent>(
+      {
+        type: "slide_analysis_progress",
+        slides: slideProgress,
+        completedCount: alreadyCompletedCount,
+        totalCount: pickedSlides.length,
+      },
+      writable,
+    );
+
+    // Phase 2: Run slide analysis for slides that don't have results
+    if (slidesNeedingAnalysis.length > 0) {
+      await emit<SuperAnalysisStreamEvent>(
+        {
+          type: "progress",
+          phase: "slide_analysis",
+          message: `Analyzing ${slidesNeedingAnalysis.length} slide(s)...`,
+        },
+        writable,
+      );
+
+      // Process slides in parallel but update progress as each completes
+      const slideProgressMap = new Map<string, SlideAnalysisProgress>(
+        slideProgress.map((s) => [`${s.slideNumber}-${s.framePosition}`, s]),
+      );
+
+      // Mark all pending slides as analyzing
+      for (const slide of slidesNeedingAnalysis) {
+        const key = `${slide.slideNumber}-${slide.framePosition}`;
+        slideProgressMap.set(key, { ...slide, status: "analyzing" });
+      }
+
+      await emit<SuperAnalysisStreamEvent>(
+        {
+          type: "slide_analysis_progress",
+          slides: Array.from(slideProgressMap.values()),
+          completedCount: alreadyCompletedCount,
+          totalCount: pickedSlides.length,
+        },
+        writable,
+      );
+
+      // Run all slide analyses in parallel
+      const slideAnalysisPromises = slidesNeedingAnalysis.map(
+        async (slideStatus) => {
+          const slideInfo = pickedSlides.find(
+            (s) =>
+              s.slideNumber === slideStatus.slideNumber &&
+              s.framePosition === slideStatus.framePosition,
+          );
+
+          if (!slideInfo) {
+            return {
+              ...slideStatus,
+              status: "failed" as const,
+              error: "Slide info not found",
+            };
+          }
+
+          try {
+            await runSingleSlideAnalysis(videoId, slideInfo);
+            return { ...slideStatus, status: "completed" as const };
+          } catch (error) {
+            const errorMsg =
+              error instanceof Error ? error.message : "Unknown error";
+            return {
+              ...slideStatus,
+              status: "failed" as const,
+              error: errorMsg,
+            };
+          }
+        },
+      );
+
+      const analysisResults = await Promise.all(slideAnalysisPromises);
+
+      // Update progress with final results
+      for (const result of analysisResults) {
+        const key = `${result.slideNumber}-${result.framePosition}`;
+        slideProgressMap.set(key, result);
+      }
+
+      const finalSlideProgress = Array.from(slideProgressMap.values());
+      const finalCompletedCount = finalSlideProgress.filter(
+        (s) => s.status === "completed",
+      ).length;
+      const failedCount = finalSlideProgress.filter(
+        (s) => s.status === "failed",
+      ).length;
+
+      await emit<SuperAnalysisStreamEvent>(
+        {
+          type: "slide_analysis_progress",
+          slides: finalSlideProgress,
+          completedCount: finalCompletedCount,
+          totalCount: pickedSlides.length,
+        },
+        writable,
+      );
+
+      if (failedCount > 0 && finalCompletedCount === 0) {
+        throw new Error("All slide analyses failed. Please try again.");
+      }
+    }
+
+    // Phase 3: Generate super analysis synthesis
     await emit<SuperAnalysisStreamEvent>(
       {
         type: "progress",


### PR DESCRIPTION
This refactor consolidates the slide analysis as a sub-step of the super analysis workflow, improving the UX by providing a unified flow.

Key changes:
- Super analysis workflow now runs slide analysis first before synthesis
- Slides panel button changed from "Analyze Selected Slides" to "Start Super Analysis"
- Super Analysis button requires checkbox confirmation before enabling
- Progress tracking shows slide analysis status with emoji indicators (⏳💭✅❌)
- Hidden slide-analysis tab (now integrated into super analysis)
- Added disabled prop support to SlideCard/FrameCard for future locking

The workflow now: Load slides → Run slide analysis (parallel) → Synthesize