### PR TITLE
Centralize UI timing and layout constants

### DIFF
--- a/components/analyze/analysis-panel.tsx
+++ b/components/analyze/analysis-panel.tsx
@@ -31,6 +31,7 @@ import {
   formatSectionTitle,
   sectionToMarkdown,
 } from "@/lib/analysis-format";
+import { UI } from "@/lib/constants";
 import { LoadingStatus } from "@/lib/status-types";
 import { isRecord } from "@/lib/type-utils";
 import { useStreamingFetch } from "@/lib/use-streaming-fetch";
@@ -78,7 +79,7 @@ export function AnalysisPanel({
     try {
       await navigator.clipboard.writeText(markdown);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => setCopied(false), UI.COPY_FEEDBACK_DURATION_MS);
     } catch (err) {
       console.error("Failed to copy:", err);
     }
@@ -90,7 +91,7 @@ export function AnalysisPanel({
     try {
       await navigator.clipboard.writeText(markdown);
       setCopiedSection(title);
-      setTimeout(() => setCopiedSection(null), 2000);
+      setTimeout(() => setCopiedSection(null), UI.COPY_FEEDBACK_DURATION_MS);
     } catch (err) {
       console.error("Failed to copy section:", err);
     }

--- a/components/analyze/slides-panel.tsx
+++ b/components/analyze/slides-panel.tsx
@@ -13,11 +13,13 @@ import {
   X,
 } from "lucide-react";
 import { useQueryStates } from "nuqs";
+import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StepIndicator } from "@/components/ui/step-indicator";
+import { UI } from "@/lib/constants";
 import { slidesPanelTabQueryConfig } from "@/lib/query-utils";
 import type {
   SlideAnalysisState,
@@ -941,17 +943,20 @@ function SlideGrid({
   const virtualizer = useVirtualizer({
     count: slides.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => 500, // Estimated height of each slide card
-    overscan: 2, // Number of items to render outside of the visible area
+    estimateSize: () => UI.SLIDE_CARD_ESTIMATED_HEIGHT, // Estimated height of each slide card
+    overscan: UI.VIRTUAL_LIST_OVERSCAN, // Number of items to render outside of the visible area
   });
+  const panelStyle = {
+    contain: "strict",
+    "--slides-panel-height": `${UI.SLIDES_PANEL_HEIGHT.mobile}px`,
+    "--slides-panel-height-desktop": `${UI.SLIDES_PANEL_HEIGHT.desktop}px`,
+  } as CSSProperties;
 
   return (
     <div
       ref={parentRef}
-      className="h-[400px] md:h-[600px] overflow-auto"
-      style={{
-        contain: "strict",
-      }}
+      className="h-[var(--slides-panel-height)] md:h-[var(--slides-panel-height-desktop)] overflow-auto"
+      style={panelStyle}
     >
       <div
         style={{

--- a/components/analyze/super-analysis-panel.tsx
+++ b/components/analyze/super-analysis-panel.tsx
@@ -14,6 +14,7 @@ import { Streamdown } from "streamdown";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { UI } from "@/lib/constants";
 import { useStreamingFetch } from "@/lib/use-streaming-fetch";
 
 // Mobile-only header with video info for super analysis
@@ -168,7 +169,7 @@ export function SuperAnalysisPanel({
     try {
       await navigator.clipboard.writeText(analysis || "");
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => setCopied(false), UI.COPY_FEEDBACK_DURATION_MS);
     } catch (err) {
       console.error("Failed to copy:", err);
     }
@@ -226,7 +227,10 @@ export function SuperAnalysisPanel({
                     onClick={() => {
                       void handleCopyMarkdown();
                       setCopiedSection(true);
-                      setTimeout(() => setCopiedSection(false), 2000);
+                      setTimeout(
+                        () => setCopiedSection(false),
+                        UI.COPY_FEEDBACK_DURATION_MS,
+                      );
                     }}
                     aria-label="Copy super analysis markdown"
                     className="gap-2 shrink-0 text-muted-foreground hover:text-foreground"

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,9 @@
+export const UI = {
+  // Copy feedback timings for clipboard interactions.
+  COPY_FEEDBACK_DURATION_MS: 2000,
+  // Virtualized slide list tuning.
+  VIRTUAL_LIST_OVERSCAN: 2,
+  SLIDE_CARD_ESTIMATED_HEIGHT: 500,
+  // Slides panel scroll container heights.
+  SLIDES_PANEL_HEIGHT: { mobile: 400, desktop: 600 },
+} as const;


### PR DESCRIPTION
### Motivation
- Remove magic numbers scattered across analysis and slides UI code to improve maintainability.
- Centralize tuning values for copy feedback, virtualized lists, and slide panel sizing so they can be adjusted in one place.
- Make the slides panel responsive while keeping Tailwind classes for layout consistency.
- Reduce duplicated configuration and make future UI tweaks safer and clearer.

### Description
- Add `lib/constants.ts` exporting a `UI` object with `COPY_FEEDBACK_DURATION_MS`, `VIRTUAL_LIST_OVERSCAN`, `SLIDE_CARD_ESTIMATED_HEIGHT`, and `SLIDES_PANEL_HEIGHT`.
- Replace hardcoded copy timeouts in `components/analyze/analysis-panel.tsx` and `components/analyze/super-analysis-panel.tsx` with `UI.COPY_FEEDBACK_DURATION_MS`.
- Replace virtualizer `estimateSize` and `overscan` and wire them to `UI.SLIDE_CARD_ESTIMATED_HEIGHT` and `UI.VIRTUAL_LIST_OVERSCAN` in `components/analyze/slides-panel.tsx`.
- Use CSS custom properties for responsive slides panel heights and satisfy TypeScript by typing the inline `style` as `CSSProperties`.

### Testing
- Ran `pnpm next typegen` and types were generated successfully.
- Ran `pnpm tsc --noEmit` and type checking completed successfully.
- Ran `pnpm test` and the test suite passed (`109` tests passed).
- Built the app with `pnpm build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949b71baf9083268a4951597e603500)