### PR TITLE
Streaming fetch data stability

### DIFF
--- a/lib/use-streaming-fetch.ts
+++ b/lib/use-streaming-fetch.ts
@@ -105,12 +105,13 @@ export function useStreamingFetch<T>(
                 }
               },
               partial: (event) => {
-                if (
-                  accumulatePartial &&
-                  typeof data === "string" &&
-                  typeof event.data === "string"
-                ) {
-                  setData((prev) => `${prev}${event.data}` as T);
+                if (accumulatePartial && typeof event.data === "string") {
+                  setData((prev) => {
+                    if (typeof prev === "string") {
+                      return `${prev}${event.data}` as T;
+                    }
+                    return event.data;
+                  });
                 } else {
                   setData(event.data);
                 }
@@ -170,7 +171,7 @@ export function useStreamingFetch<T>(
         statusMessageRef.current("");
       }
     },
-    [url, initialData, accumulatePartial, data],
+    [url, initialData, accumulatePartial],
   );
 
   const refetch = useCallback(() => {


### PR DESCRIPTION
Stabilize `fetchData` and fix stale `data` reads in the partial handler by removing `data` from its dependencies and using functional `setData` updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-e552f855-a622-46d9-869d-9f1c3ade452b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e552f855-a622-46d9-869d-9f1c3ade452b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

