### PR TITLE
Ensure yt-dlp binary is available at runtime

### DIFF
--- a/lib/fetch-and-save-transcript.ts
+++ b/lib/fetch-and-save-transcript.ts
@@ -6,7 +6,7 @@ Moved the fetch-and-save-transcript logic from the workflow directly into a lib 
 Tried to reuse the workflow steps directly but stumbled upon another issue https://github.com/vercel/workflow/issues/630, where you can't call a step function outside of a workflow if that functions uses dependencies not marked with "use step"
 */
 
-import { access, chmod, mkdir, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, rename, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { Payload as YtDlpPayload } from "youtube-dl-exec";
@@ -114,6 +114,22 @@ function getYtDlpBinaryName(): string {
   return process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp";
 }
 
+function getYtDlpDownloadName(): string {
+  if (process.env.YOUTUBE_DL_FILENAME?.trim()) {
+    return process.env.YOUTUBE_DL_FILENAME.trim();
+  }
+
+  if (process.platform === "win32") {
+    return "yt-dlp.exe";
+  }
+
+  if (process.platform === "darwin") {
+    return "yt-dlp_macos";
+  }
+
+  return "yt-dlp_linux";
+}
+
 function getYtDlpBinaryPath(): string {
   if (process.env.YOUTUBE_DL_PATH?.trim()) {
     return process.env.YOUTUBE_DL_PATH.trim();
@@ -136,7 +152,7 @@ async function ensureYtDlpBinary(): Promise<string> {
     const binaryDir = path.dirname(binaryPath);
     await mkdir(binaryDir, { recursive: true });
 
-    const downloadUrl = `${YT_DLP_DOWNLOAD_BASE_URL}/${getYtDlpBinaryName()}`;
+    const downloadUrl = `${YT_DLP_DOWNLOAD_BASE_URL}/${getYtDlpDownloadName()}`;
     console.log(`[yt-dlp] Downloading yt-dlp binary from: ${downloadUrl}`);
 
     const response = await fetch(downloadUrl);
@@ -147,12 +163,30 @@ async function ensureYtDlpBinary(): Promise<string> {
     }
 
     const buffer = Buffer.from(await response.arrayBuffer());
-    await writeFile(binaryPath, buffer);
-
-    if (process.platform !== "win32") {
-      await chmod(binaryPath, 0o755);
+    if (buffer.length < 100_000) {
+      throw new Error(
+        `[yt-dlp] Downloaded yt-dlp binary is unexpectedly small (${buffer.length} bytes).`,
+      );
     }
 
+    const tempPath = `${binaryPath}.download`;
+    await writeFile(tempPath, buffer);
+
+    if (process.platform !== "win32") {
+      await chmod(tempPath, 0o755);
+    }
+
+    try {
+      await rename(tempPath, binaryPath);
+    } catch (error) {
+      await access(binaryPath);
+      await access(tempPath).then(
+        () => {
+          throw error;
+        },
+        () => undefined,
+      );
+    }
     return binaryPath;
   }
 }

--- a/lib/fetch-and-save-transcript.ts
+++ b/lib/fetch-and-save-transcript.ts
@@ -5,6 +5,10 @@ Moved the fetch-and-save-transcript logic from the workflow directly into a lib 
 
 Tried to reuse the workflow steps directly but stumbled upon another issue https://github.com/vercel/workflow/issues/630, where you can't call a step function outside of a workflow if that functions uses dependencies not marked with "use step"
 */
+
+import { access, chmod, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { Payload as YtDlpPayload } from "youtube-dl-exec";
 import { z } from "zod";
 import { getVideoWithTranscript } from "@/db/queries";
@@ -63,6 +67,9 @@ const YtDlpSubtitlesSchema = z.object({
 // yt-dlp Helpers
 // ============================================================================
 
+const YT_DLP_DOWNLOAD_BASE_URL =
+  "https://github.com/yt-dlp/yt-dlp/releases/latest/download";
+
 function formatDurationFromSeconds(seconds: number): string {
   const hours = Math.floor(seconds / 3600);
   const mins = Math.floor((seconds % 3600) / 60);
@@ -97,6 +104,57 @@ function parseVttTimestamp(timestamp: string): number {
     );
   }
   return 0;
+}
+
+function getYtDlpBinaryName(): string {
+  if (process.env.YOUTUBE_DL_FILENAME?.trim()) {
+    return process.env.YOUTUBE_DL_FILENAME.trim();
+  }
+
+  return process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp";
+}
+
+function getYtDlpBinaryPath(): string {
+  if (process.env.YOUTUBE_DL_PATH?.trim()) {
+    return process.env.YOUTUBE_DL_PATH.trim();
+  }
+
+  const binaryDir =
+    process.env.YOUTUBE_DL_DIR?.trim() ??
+    path.join(os.tmpdir(), "video2md-yt-dlp");
+
+  return path.join(binaryDir, getYtDlpBinaryName());
+}
+
+async function ensureYtDlpBinary(): Promise<string> {
+  const binaryPath = getYtDlpBinaryPath();
+
+  try {
+    await access(binaryPath);
+    return binaryPath;
+  } catch {
+    const binaryDir = path.dirname(binaryPath);
+    await mkdir(binaryDir, { recursive: true });
+
+    const downloadUrl = `${YT_DLP_DOWNLOAD_BASE_URL}/${getYtDlpBinaryName()}`;
+    console.log(`[yt-dlp] Downloading yt-dlp binary from: ${downloadUrl}`);
+
+    const response = await fetch(downloadUrl);
+    if (!response.ok) {
+      throw new Error(
+        `[yt-dlp] Failed to download yt-dlp binary: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    await writeFile(binaryPath, buffer);
+
+    if (process.platform !== "win32") {
+      await chmod(binaryPath, 0o755);
+    }
+
+    return binaryPath;
+  }
 }
 
 // Parse VTT/SRT subtitle text into TranscriptSegment[]
@@ -207,7 +265,17 @@ async function fetchYoutubeTranscriptFromYtDlp(
   }
 
   const youtubeDlExec = await import("youtube-dl-exec");
-  const ytDlp = youtubeDlExec.default;
+  const ytDlpBinaryPath = await ensureYtDlpBinary();
+  const create =
+    "create" in youtubeDlExec && typeof youtubeDlExec.create === "function"
+      ? youtubeDlExec.create
+      : youtubeDlExec.default.create;
+
+  if (typeof create !== "function") {
+    throw new Error("[yt-dlp] Failed to initialize yt-dlp binary wrapper.");
+  }
+
+  const ytDlp = create(ytDlpBinaryPath);
 
   // Build proxy URL from environment variables
   const zyteApiKey = process.env.ZYTE_API_KEY;

--- a/lib/fetch-and-save-transcript.ts
+++ b/lib/fetch-and-save-transcript.ts
@@ -151,6 +151,12 @@ async function ensureYtDlpBinary(): Promise<string> {
   } catch {
     const binaryDir = path.dirname(binaryPath);
     await mkdir(binaryDir, { recursive: true });
+    try {
+      await access(binaryPath);
+      return binaryPath;
+    } catch {
+      // proceed with download
+    }
 
     const downloadUrl = `${YT_DLP_DOWNLOAD_BASE_URL}/${getYtDlpDownloadName()}`;
     console.log(`[yt-dlp] Downloading yt-dlp binary from: ${downloadUrl}`);
@@ -173,7 +179,17 @@ async function ensureYtDlpBinary(): Promise<string> {
     await writeFile(tempPath, buffer);
 
     if (process.platform !== "win32") {
-      await chmod(tempPath, 0o755);
+      try {
+        await chmod(tempPath, 0o755);
+      } catch (error) {
+        await access(binaryPath);
+        await access(tempPath).then(
+          () => {
+            throw error;
+          },
+          () => undefined,
+        );
+      }
     }
 
     try {
@@ -327,16 +343,21 @@ async function fetchYoutubeTranscriptFromYtDlp(
 
   console.log(`[yt-dlp] Fetching metadata for video: ${videoId}`);
 
-  // Fetch video metadata and subtitle info using yt-dlp
-  const result = await ytDlp(videoUrl, {
+  const ytDlpOptions: Record<string, unknown> = {
     dumpSingleJson: true,
     noWarnings: true,
     skipDownload: true,
     proxy: proxyUrl,
     noCacheDir: true,
-    noCheckCertificates: disableTlsVerify,
     forceIpv4: true,
-  });
+  };
+
+  if (disableTlsVerify) {
+    ytDlpOptions.noCheckCertificates = true;
+  }
+
+  // Fetch video metadata and subtitle info using yt-dlp
+  const result = await ytDlp(videoUrl, ytDlpOptions);
 
   // When using dumpSingleJson, the result is a Payload object, not a string
   if (typeof result === "string") {


### PR DESCRIPTION
### Motivation
- Calls to `youtube-dl-exec` were failing with `ENOENT` because the `yt-dlp` binary may be missing when postinstall scripts are skipped. 
- The runtime should be able to download or use an explicitly configured binary so transcript fetching doesn't crash in environments without the bundled binary.

### Description
- Added a runtime bootstrap in `lib/fetch-and-save-transcript.ts` that downloads a `yt-dlp` binary to a temp (or configured) path and makes it executable via `ensureYtDlpBinary`, `getYtDlpBinaryPath`, and `getYtDlpBinaryName` helpers. 
- Added `YT_DLP_DOWNLOAD_BASE_URL` and downloading logic using `fetch` plus `node:fs/promises` APIs to write and `chmod` the binary. 
- Updated `fetchYoutubeTranscriptFromYtDlp` to call `youtube-dl-exec.create` with the ensured binary path (and fail fast if the wrapper cannot be initialized). 
- Respect environment overrides via `YOUTUBE_DL_PATH`, `YOUTUBE_DL_DIR`, and `YOUTUBE_DL_FILENAME` so deployments can control where the binary is read from.

### Testing
- Ran formatting and lint fixes with `pnpm format` and `pnpm fix` (succeeded). 
- Ran unit tests with `pnpm test`, and the test suite passed (143 tests passed). 
- Ran `pnpm next typegen` and `pnpm tsc --noEmit` (succeeded). 
- Built the app with `pnpm build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e77d1b74832690c6ac3702774860)