### PR TITLE
Auto-restart failed or cancelled workflows

### DIFF
--- a/lib/workflow-route-utils.test.ts
+++ b/lib/workflow-route-utils.test.ts
@@ -115,6 +115,74 @@ describe("createWorkflowRouteHandler", () => {
     );
   });
 
+  it("should restart workflow if status is failed", async () => {
+    const videoId = "videoFail1" as YouTubeVideoId;
+    const workflowId = "wrun_fail1";
+
+    mockGetWorkflowRecord.mockResolvedValue({ workflowId });
+
+    const mockRun = {
+      status: Promise.resolve("failed"),
+      readable: new ReadableStream(),
+    };
+
+    // biome-ignore lint/suspicious/noExplicitAny: Mocking internal workflow type
+    vi.mocked(workflowApi.getRun).mockReturnValue(mockRun as any);
+
+    const handler = createWorkflowRouteHandler({
+      getCompletedResult: mockGetCompletedResult,
+      getWorkflowRecord: mockGetWorkflowRecord,
+      startWorkflow: mockStartWorkflow,
+      extractWorkflowId: mockExtractWorkflowId,
+      logger: mockLogger,
+    });
+
+    const response = await handler(videoId);
+
+    expect(mockStartWorkflow).toHaveBeenCalledWith(videoId);
+    expect(response).toBeDefined();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Workflow failed or cancelled, attempting to restart",
+      { videoId, workflowId, status: "failed" },
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Workflow restart succeeded after failure",
+      { videoId, workflowId },
+    );
+  });
+
+  it("should restart workflow if status is cancelled", async () => {
+    const videoId = "videoCncl1" as YouTubeVideoId;
+    const workflowId = "wrun_cncl1";
+
+    mockGetWorkflowRecord.mockResolvedValue({ workflowId });
+
+    const mockRun = {
+      status: Promise.resolve("cancelled"),
+      readable: new ReadableStream(),
+    };
+
+    // biome-ignore lint/suspicious/noExplicitAny: Mocking internal workflow type
+    vi.mocked(workflowApi.getRun).mockReturnValue(mockRun as any);
+
+    const handler = createWorkflowRouteHandler({
+      getCompletedResult: mockGetCompletedResult,
+      getWorkflowRecord: mockGetWorkflowRecord,
+      startWorkflow: mockStartWorkflow,
+      extractWorkflowId: mockExtractWorkflowId,
+      logger: mockLogger,
+    });
+
+    const response = await handler(videoId);
+
+    expect(mockStartWorkflow).toHaveBeenCalledWith(videoId);
+    expect(response).toBeDefined();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Workflow failed or cancelled, attempting to restart",
+      { videoId, workflowId, status: "cancelled" },
+    );
+  });
+
   it("should log error when unexpected error occurs", async () => {
     const videoId = "video789" as YouTubeVideoId;
     const workflowId = "wrun_789";

--- a/lib/workflow-route-utils.ts
+++ b/lib/workflow-route-utils.ts
@@ -108,6 +108,31 @@ export function createWorkflowRouteHandler<TCompletedResult, TWorkflowRecord>(
         });
         throw err;
       }
+
+      // Auto-restart failed or cancelled workflows
+      if (status === "failed" || status === "cancelled") {
+        logger.info("Workflow failed or cancelled, attempting to restart", {
+          videoId,
+          workflowId,
+          status,
+        });
+
+        try {
+          const response = await options.startWorkflow(videoId);
+          logger.info("Workflow restart succeeded after failure", {
+            videoId,
+            workflowId,
+          });
+          return response;
+        } catch (restartError) {
+          logger.error("Workflow restart after failure failed", restartError, {
+            videoId,
+            workflowId,
+          });
+          throw restartError;
+        }
+      }
+
       const readable = run.readable;
 
       // Allow custom status handling (e.g., for restarting failed workflows)


### PR DESCRIPTION
## Summary
Added automatic workflow restart functionality to handle failed or cancelled workflow runs. When a workflow reaches a failed or cancelled status, the system now automatically attempts to restart it instead of propagating the error.

## Key Changes
- Added status check in `createWorkflowRouteHandler` to detect failed or cancelled workflows
- Implemented automatic restart logic that calls `startWorkflow` when either status is detected
- Added comprehensive logging for restart attempts and outcomes
- Included error handling for restart failures with appropriate error propagation
- Added test coverage for both failed and cancelled workflow restart scenarios

## Implementation Details
- The auto-restart logic is placed after the initial error handling but before streaming the readable response
- Both "failed" and "cancelled" statuses trigger the same restart behavior
- Restart attempts are logged with the original workflow ID and status for debugging purposes
- If the restart itself fails, the error is logged and re-thrown to maintain error visibility
- Tests verify that `startWorkflow` is called and appropriate log messages are generated for both failure scenarios

https://claude.ai/code/session_01DjEFvg7aLT3dbVg15spXad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows that fail or are cancelled now automatically restart without manual intervention.
  * Enhanced logging provides visibility into restart attempts, including video ID, workflow ID, and status information.
  * Errors during restart attempts are captured and logged appropriately.

* **Tests**
  * Added test coverage for automatic restart functionality when workflows reach failed or cancelled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->