### PR TITLE
Exclude .agents directory from Biome linting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,14 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build",
+      "!.agents/**"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary
Updated the Biome configuration to exclude the `.agents/` directory from file processing, alongside existing exclusions for build artifacts and dependencies.

## Changes
- Added `!.agents/**` to the `files.includes` array in `biome.json` to prevent Biome from linting files in the `.agents` directory
- Reformatted the `includes` array for improved readability with one pattern per line

## Details
This change ensures that any files within the `.agents/` directory are ignored during Biome's linting and formatting operations, similar to how `node_modules`, `.next`, `dist`, and `build` directories are already excluded. This is useful for keeping generated or third-party agent code out of the linting scope.

https://claude.ai/code/session_01EBPtK7uSakdAcg8zK8wQaw