### PR TITLE
Eagerly start slide extraction on analyze page load

### DIFF
--- a/.agents/skills/ai-elements/scripts/agent.tsx
+++ b/.agents/skills/ai-elements/scripts/agent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { z } from "zod";
 import {
   Agent,
   AgentContent,
@@ -9,7 +10,6 @@ import {
   AgentTool,
   AgentTools,
 } from "@/components/ai-elements/agent";
-import { z } from "zod";
 
 const webSearchTool = {
   description: "Search the web for information",

--- a/.agents/skills/ai-elements/scripts/artifact.tsx
+++ b/.agents/skills/ai-elements/scripts/artifact.tsx
@@ -1,6 +1,13 @@
 "use client";
 
 import {
+  CopyIcon,
+  DownloadIcon,
+  PlayIcon,
+  RefreshCwIcon,
+  ShareIcon,
+} from "lucide-react";
+import {
   Artifact,
   ArtifactAction,
   ArtifactActions,
@@ -10,13 +17,6 @@ import {
   ArtifactTitle,
 } from "@/components/ai-elements/artifact";
 import { CodeBlock } from "@/components/ai-elements/code-block";
-import {
-  CopyIcon,
-  DownloadIcon,
-  PlayIcon,
-  RefreshCwIcon,
-  ShareIcon,
-} from "lucide-react";
 
 const handleRun = () => {
   console.log("Run");

--- a/.agents/skills/ai-elements/scripts/attachments-inline.tsx
+++ b/.agents/skills/ai-elements/scripts/attachments-inline.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { nanoid } from "nanoid";
+import { memo, useCallback, useState } from "react";
 import {
   Attachment,
   AttachmentHoverCard,
@@ -12,8 +14,6 @@ import {
   getAttachmentLabel,
   getMediaCategory,
 } from "@/components/ai-elements/attachments";
-import { nanoid } from "nanoid";
-import { memo, useCallback, useState } from "react";
 
 const initialAttachments = [
   {
@@ -54,7 +54,7 @@ interface AttachmentItemProps {
 const AttachmentItem = memo(({ attachment, onRemove }: AttachmentItemProps) => {
   const handleRemove = useCallback(
     () => onRemove(attachment.id),
-    [onRemove, attachment.id]
+    [onRemove, attachment.id],
   );
   const mediaCategory = getMediaCategory(attachment);
   const label = getAttachmentLabel(attachment);

--- a/.agents/skills/ai-elements/scripts/attachments-list.tsx
+++ b/.agents/skills/ai-elements/scripts/attachments-list.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { nanoid } from "nanoid";
+import { memo, useCallback, useState } from "react";
 import {
   Attachment,
   AttachmentInfo,
@@ -7,8 +9,6 @@ import {
   AttachmentRemove,
   Attachments,
 } from "@/components/ai-elements/attachments";
-import { nanoid } from "nanoid";
-import { memo, useCallback, useState } from "react";
 
 const initialAttachments = [
   {
@@ -57,7 +57,7 @@ interface AttachmentItemProps {
 const AttachmentItem = memo(({ attachment, onRemove }: AttachmentItemProps) => {
   const handleRemove = useCallback(
     () => onRemove(attachment.id),
-    [onRemove, attachment.id]
+    [onRemove, attachment.id],
   );
   return (
     <Attachment data={attachment} key={attachment.id} onRemove={handleRemove}>

--- a/.agents/skills/ai-elements/scripts/attachments.tsx
+++ b/.agents/skills/ai-elements/scripts/attachments.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { nanoid } from "nanoid";
+import { memo, useCallback, useState } from "react";
 import {
   Attachment,
   AttachmentPreview,
   AttachmentRemove,
   Attachments,
 } from "@/components/ai-elements/attachments";
-import { nanoid } from "nanoid";
-import { memo, useCallback, useState } from "react";
 
 const initialAttachments = [
   {
@@ -48,7 +48,7 @@ interface AttachmentItemProps {
 const AttachmentItem = memo(({ attachment, onRemove }: AttachmentItemProps) => {
   const handleRemove = useCallback(
     () => onRemove(attachment.id),
-    [onRemove, attachment.id]
+    [onRemove, attachment.id],
   );
   return (
     <Attachment data={attachment} onRemove={handleRemove}>

--- a/.agents/skills/ai-elements/scripts/audio-player.tsx
+++ b/.agents/skills/ai-elements/scripts/audio-player.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Experimental_SpeechResult as SpeechResult } from "ai";
-
+import { useEffect, useState } from "react";
 import {
   AudioPlayer,
   AudioPlayerControlBar,
@@ -15,7 +15,6 @@ import {
   AudioPlayerTimeRange,
   AudioPlayerVolumeRange,
 } from "@/components/ai-elements/audio-player";
-import { useEffect, useState } from "react";
 
 const Example = () => {
   const [data, setData] = useState<SpeechResult["audio"] | null>(null);
@@ -23,7 +22,7 @@ const Example = () => {
   useEffect(() => {
     const fetchData = async () => {
       const response = await fetch(
-        "https://ejiidnob33g9ap1r.public.blob.vercel-storage.com/ElevenLabs_2025-11-10T22_07_46_Hayden_pvc_sp108_s50_sb75_se0_b_m2.mp3"
+        "https://ejiidnob33g9ap1r.public.blob.vercel-storage.com/ElevenLabs_2025-11-10T22_07_46_Hayden_pvc_sp108_s50_sb75_se0_b_m2.mp3",
       );
       const arrayBuffer = await response.arrayBuffer();
       const base64 = Buffer.from(arrayBuffer).toString("base64");

--- a/.agents/skills/ai-elements/scripts/chain-of-thought.tsx
+++ b/.agents/skills/ai-elements/scripts/chain-of-thought.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ImageIcon, SearchIcon } from "lucide-react";
 import {
   ChainOfThought,
   ChainOfThoughtContent,
@@ -10,7 +11,6 @@ import {
   ChainOfThoughtStep,
 } from "@/components/ai-elements/chain-of-thought";
 import { Image } from "@/components/ai-elements/image";
-import { ImageIcon, SearchIcon } from "lucide-react";
 
 const exampleImage = {
   base64:
@@ -71,7 +71,7 @@ const ChainOfThoughtExample = () => (
               <ChainOfThoughtSearchResult key={website}>
                 {new URL(website).hostname}
               </ChainOfThoughtSearchResult>
-            )
+            ),
           )}
         </ChainOfThoughtSearchResults>
       </ChainOfThoughtStep>

--- a/.agents/skills/ai-elements/scripts/checkpoint.tsx
+++ b/.agents/skills/ai-elements/scripts/checkpoint.tsx
@@ -1,18 +1,21 @@
 "use client";
 
+import { nanoid } from "nanoid";
+import { Fragment, memo, useCallback, useState } from "react";
 import {
   Checkpoint,
   CheckpointIcon,
   CheckpointTrigger,
 } from "@/components/ai-elements/checkpoint";
-import { Conversation, ConversationContent } from "@/components/ai-elements/conversation";
+import {
+  Conversation,
+  ConversationContent,
+} from "@/components/ai-elements/conversation";
 import {
   Message,
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
-import { nanoid } from "nanoid";
-import { Fragment, memo, useCallback, useState } from "react";
 
 interface MessageType {
   id: string;
@@ -48,7 +51,7 @@ const CheckpointItem = memo(
   ({ checkpoint, onRestore }: CheckpointItemProps) => {
     const handleClick = useCallback(
       () => onRestore(checkpoint.messageCount),
-      [onRestore, checkpoint.messageCount]
+      [onRestore, checkpoint.messageCount],
     );
     return (
       <Checkpoint>
@@ -61,7 +64,7 @@ const CheckpointItem = memo(
         </CheckpointTrigger>
       </Checkpoint>
     );
-  }
+  },
 );
 
 CheckpointItem.displayName = "CheckpointItem";
@@ -82,7 +85,7 @@ const Example = () => {
         <ConversationContent>
           {messages.map((message, index) => {
             const checkpoint = checkpoints.find(
-              (cp) => cp.messageCount === index + 1
+              (cp) => cp.messageCount === index + 1,
             );
 
             return (

--- a/.agents/skills/ai-elements/scripts/code-block-dark.tsx
+++ b/.agents/skills/ai-elements/scripts/code-block-dark.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FileIcon } from "lucide-react";
 import {
   CodeBlock,
   CodeBlockActions,
@@ -8,7 +9,6 @@ import {
   CodeBlockHeader,
   CodeBlockTitle,
 } from "@/components/ai-elements/code-block";
-import { FileIcon } from "lucide-react";
 
 const handleCopy = () => {
   console.log("Copied code to clipboard");

--- a/.agents/skills/ai-elements/scripts/code-block.tsx
+++ b/.agents/skills/ai-elements/scripts/code-block.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { FileIcon } from "lucide-react";
+import { useCallback, useState } from "react";
 import type { BundledLanguage } from "shiki";
-
 import {
   CodeBlock,
   CodeBlockActions,
@@ -15,8 +16,6 @@ import {
   CodeBlockLanguageSelectorValue,
   CodeBlockTitle,
 } from "@/components/ai-elements/code-block";
-import { FileIcon } from "lucide-react";
-import { useCallback, useState } from "react";
 
 const codeExamples = {
   go: {

--- a/.agents/skills/ai-elements/scripts/confirmation-accepted.tsx
+++ b/.agents/skills/ai-elements/scripts/confirmation-accepted.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { CheckIcon, XIcon } from "lucide-react";
+import { nanoid } from "nanoid";
 import {
   Confirmation,
   ConfirmationAccepted,
@@ -7,8 +9,6 @@ import {
   ConfirmationRequest,
   ConfirmationTitle,
 } from "@/components/ai-elements/confirmation";
-import { CheckIcon, XIcon } from "lucide-react";
-import { nanoid } from "nanoid";
 
 const Example = () => (
   <div className="w-full max-w-2xl">

--- a/.agents/skills/ai-elements/scripts/confirmation-rejected.tsx
+++ b/.agents/skills/ai-elements/scripts/confirmation-rejected.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { CheckIcon, XIcon } from "lucide-react";
+import { nanoid } from "nanoid";
 import {
   Confirmation,
   ConfirmationAccepted,
@@ -7,8 +9,6 @@ import {
   ConfirmationRequest,
   ConfirmationTitle,
 } from "@/components/ai-elements/confirmation";
-import { CheckIcon, XIcon } from "lucide-react";
-import { nanoid } from "nanoid";
 
 const Example = () => (
   <div className="w-full max-w-2xl">

--- a/.agents/skills/ai-elements/scripts/confirmation-request.tsx
+++ b/.agents/skills/ai-elements/scripts/confirmation-request.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { CheckIcon, XIcon } from "lucide-react";
+import { nanoid } from "nanoid";
 import {
   Confirmation,
   ConfirmationAccepted,
@@ -9,8 +11,6 @@ import {
   ConfirmationRequest,
   ConfirmationTitle,
 } from "@/components/ai-elements/confirmation";
-import { CheckIcon, XIcon } from "lucide-react";
-import { nanoid } from "nanoid";
 
 const handleReject = () => {
   // In production, call respondToConfirmationRequest with approved: false

--- a/.agents/skills/ai-elements/scripts/confirmation.tsx
+++ b/.agents/skills/ai-elements/scripts/confirmation.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { CheckIcon, XIcon } from "lucide-react";
+import { nanoid } from "nanoid";
 import {
   Confirmation,
   ConfirmationAccepted,
@@ -9,8 +11,6 @@ import {
   ConfirmationRequest,
   ConfirmationTitle,
 } from "@/components/ai-elements/confirmation";
-import { CheckIcon, XIcon } from "lucide-react";
-import { nanoid } from "nanoid";
 
 const handleReject = () => {
   // In production, call respondToConfirmationRequest with approved: false

--- a/.agents/skills/ai-elements/scripts/conversation.tsx
+++ b/.agents/skills/ai-elements/scripts/conversation.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { MessageSquareIcon } from "lucide-react";
+import { nanoid } from "nanoid";
+import { useEffect, useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -8,9 +11,6 @@ import {
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
 import { Message, MessageContent } from "@/components/ai-elements/message";
-import { MessageSquareIcon } from "lucide-react";
-import { nanoid } from "nanoid";
-import { useEffect, useState } from "react";
 
 const messages: {
   key: string;

--- a/.agents/skills/ai-elements/scripts/file-tree-selection.tsx
+++ b/.agents/skills/ai-elements/scripts/file-tree-selection.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import {
   FileTree,
   FileTreeFile,
   FileTreeFolder,
 } from "@/components/ai-elements/file-tree";
-import { useState } from "react";
 
 const Example = () => {
   const [selectedPath, setSelectedPath] = useState<string>();

--- a/.agents/skills/ai-elements/scripts/file-tree.tsx
+++ b/.agents/skills/ai-elements/scripts/file-tree.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import {
   FileTree,
   FileTreeFile,
   FileTreeFolder,
 } from "@/components/ai-elements/file-tree";
-import { useState } from "react";
 
 const Example = () => {
   const [selectedPath, setSelectedPath] = useState<string | undefined>();

--- a/.agents/skills/ai-elements/scripts/jsx-preview.tsx
+++ b/.agents/skills/ai-elements/scripts/jsx-preview.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   JSXPreview,
   JSXPreviewContent,
   JSXPreviewError,
 } from "@/components/ai-elements/jsx-preview";
 import { Button } from "@/components/ui/button";
-import { useCallback, useEffect, useRef, useState } from "react";
 
 const handleError = (error: Error) => {
   console.log("JSX Parse Error:", error);
@@ -74,7 +74,7 @@ const Example = () => {
         clearInterval(intervalRef.current);
       }
     },
-    []
+    [],
   );
 
   return (

--- a/.agents/skills/ai-elements/scripts/message.tsx
+++ b/.agents/skills/ai-elements/scripts/message.tsx
@@ -1,6 +1,14 @@
 "use client";
 
 import {
+  CopyIcon,
+  RefreshCcwIcon,
+  ThumbsDownIcon,
+  ThumbsUpIcon,
+} from "lucide-react";
+import { nanoid } from "nanoid";
+import { memo, useCallback, useState } from "react";
+import {
   Attachment,
   AttachmentPreview,
   AttachmentRemove,
@@ -20,14 +28,6 @@ import {
   MessageResponse,
   MessageToolbar,
 } from "@/components/ai-elements/message";
-import {
-  CopyIcon,
-  RefreshCcwIcon,
-  ThumbsDownIcon,
-  ThumbsUpIcon,
-} from "lucide-react";
-import { nanoid } from "nanoid";
-import { memo, useCallback, useState } from "react";
 
 const messages: {
   key: string;
@@ -186,7 +186,7 @@ const LikeAction = memo(
   ({ messageKey, isLiked, onToggle }: LikeActionProps) => {
     const handleClick = useCallback(
       () => onToggle(messageKey),
-      [messageKey, onToggle]
+      [messageKey, onToggle],
     );
     return (
       <MessageAction
@@ -200,7 +200,7 @@ const LikeAction = memo(
         />
       </MessageAction>
     );
-  }
+  },
 );
 
 LikeAction.displayName = "LikeAction";
@@ -215,7 +215,7 @@ const DislikeAction = memo(
   ({ messageKey, isDisliked, onToggle }: DislikeActionProps) => {
     const handleClick = useCallback(
       () => onToggle(messageKey),
-      [messageKey, onToggle]
+      [messageKey, onToggle],
     );
     return (
       <MessageAction
@@ -229,7 +229,7 @@ const DislikeAction = memo(
         />
       </MessageAction>
     );
-  }
+  },
 );
 
 DislikeAction.displayName = "DislikeAction";

--- a/.agents/skills/ai-elements/scripts/model-selector.tsx
+++ b/.agents/skills/ai-elements/scripts/model-selector.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { CheckIcon } from "lucide-react";
+import { memo, useCallback, useState } from "react";
 import {
   ModelSelector,
   ModelSelectorContent,
@@ -14,8 +16,6 @@ import {
   ModelSelectorTrigger,
 } from "@/components/ai-elements/model-selector";
 import { Button } from "@/components/ui/button";
-import { CheckIcon } from "lucide-react";
-import { memo, useCallback, useState } from "react";
 
 const models = [
   {
@@ -288,7 +288,7 @@ interface ModelItemProps {
 const ModelItem = memo(({ model, selectedModel, onSelect }: ModelItemProps) => {
   const handleSelect = useCallback(
     () => onSelect(model.id),
-    [onSelect, model.id]
+    [onSelect, model.id],
   );
   return (
     <ModelSelectorItem key={model.id} onSelect={handleSelect} value={model.id}>

--- a/.agents/skills/ai-elements/scripts/persona-command.tsx
+++ b/.agents/skills/ai-elements/scripts/persona-command.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import type { PersonaState } from "@/components/ai-elements/persona";
 import type { LucideIcon } from "lucide-react";
-
-import { Persona } from "@/components/ai-elements/persona";
-import { Button } from "@/components/ui/button";
-import { ButtonGroup } from "@/components/ui/button-group";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import {
   BrainIcon,
   CircleIcon,
@@ -19,6 +9,15 @@ import {
   MicIcon,
 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
+import type { PersonaState } from "@/components/ai-elements/persona";
+import { Persona } from "@/components/ai-elements/persona";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const states: {
   state: PersonaState;
@@ -62,7 +61,7 @@ const StateButton = memo(
   ({ state, currentState, onStateChange }: StateButtonProps) => {
     const handleClick = useCallback(
       () => onStateChange(state.state),
-      [onStateChange, state.state]
+      [onStateChange, state.state],
     );
     return (
       <Tooltip key={state.state}>
@@ -78,7 +77,7 @@ const StateButton = memo(
         <TooltipContent>{state.label}</TooltipContent>
       </Tooltip>
     );
-  }
+  },
 );
 
 StateButton.displayName = "StateButton";

--- a/.agents/skills/ai-elements/scripts/persona-glint.tsx
+++ b/.agents/skills/ai-elements/scripts/persona-glint.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import type { PersonaState } from "@/components/ai-elements/persona";
 import type { LucideIcon } from "lucide-react";
-
-import { Persona } from "@/components/ai-elements/persona";
-import { Button } from "@/components/ui/button";
-import { ButtonGroup } from "@/components/ui/button-group";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import {
   BrainIcon,
   CircleIcon,
@@ -19,6 +9,15 @@ import {
   MicIcon,
 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
+import type { PersonaState } from "@/components/ai-elements/persona";
+import { Persona } from "@/components/ai-elements/persona";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const states: {
   state: PersonaState;
@@ -62,7 +61,7 @@ const StateButton = memo(
   ({ state, currentState, onStateChange }: StateButtonProps) => {
     const handleClick = useCallback(
       () => onStateChange(state.state),
-      [onStateChange, state.state]
+      [onStateChange, state.state],
     );
     return (
       <Tooltip key={state.state}>
@@ -78,7 +77,7 @@ const StateButton = memo(
         <TooltipContent>{state.label}</TooltipContent>
       </Tooltip>
     );
-  }
+  },
 );
 
 StateButton.displayName = "StateButton";

--- a/.agents/skills/ai-elements/scripts/persona-halo.tsx
+++ b/.agents/skills/ai-elements/scripts/persona-halo.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import type { PersonaState } from "@/components/ai-elements/persona";
 import type { LucideIcon } from "lucide-react";
-
-import { Persona } from "@/components/ai-elements/persona";
-import { Button } from "@/components/ui/button";
-import { ButtonGroup } from "@/components/ui/button-group";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import {
   BrainIcon,
   CircleIcon,
@@ -19,6 +9,15 @@ import {
   MicIcon,
 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
+import type { PersonaState } from "@/components/ai-elements/persona";
+import { Persona } from "@/components/ai-elements/persona";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const states: {
   state: PersonaState;
@@ -62,7 +61,7 @@ const StateButton = memo(
   ({ state, currentState, onStateChange }: StateButtonProps) => {
     const handleClick = useCallback(
       () => onStateChange(state.state),
-      [onStateChange, state.state]
+      [onStateChange, state.state],
     );
     return (
       <Tooltip key={state.state}>
@@ -78,7 +77,7 @@ const StateButton = memo(
         <TooltipContent>{state.label}</TooltipContent>
       </Tooltip>
     );
-  }
+  },
 );
 
 StateButton.displayName = "StateButton";

--- a/.agents/skills/ai-elements/scripts/persona-mana.tsx
+++ b/.agents/skills/ai-elements/scripts/persona-mana.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import type { PersonaState } from "@/components/ai-elements/persona";
 import type { LucideIcon } from "lucide-react";
-
-import { Persona } from "@/components/ai-elements/persona";
-import { Button } from "@/components/ui/button";
-import { ButtonGroup } from "@/components/ui/button-group";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import {
   BrainIcon,
   CircleIcon,
@@ -19,6 +9,15 @@ import {
   MicIcon,
 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
+import type { PersonaState } from "@/components/ai-elements/persona";
+import { Persona } from "@/components/ai-elements/persona";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const states: {
   state: PersonaState;
@@ -62,7 +61,7 @@ const StateButton = memo(
   ({ state, currentState, onStateChange }: StateButtonProps) => {
     const handleClick = useCallback(
       () => onStateChange(state.state),
-      [onStateChange, state.state]
+      [onStateChange, state.state],
     );
     return (
       <Tooltip key={state.state}>
@@ -78,7 +77,7 @@ const StateButton = memo(
         <TooltipContent>{state.label}</TooltipContent>
       </Tooltip>
     );
-  }
+  },
 );
 
 StateButton.displayName = "StateButton";

--- a/.agents/skills/ai-elements/scripts/persona-obsidian.tsx
+++ b/.agents/skills/ai-elements/scripts/persona-obsidian.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import type { PersonaState } from "@/components/ai-elements/persona";
 import type { LucideIcon } from "lucide-react";
-
-import { Persona } from "@/components/ai-elements/persona";
-import { Button } from "@/components/ui/button";
-import { ButtonGroup } from "@/components/ui/button-group";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import {
   BrainIcon,
   CircleIcon,
@@ -19,6 +9,15 @@ import {
   MicIcon,
 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
+import type { PersonaState } from "@/components/ai-elements/persona";
+import { Persona } from "@/components/ai-elements/persona";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const states: {
   state: PersonaState;
@@ -62,7 +61,7 @@ const StateButton = memo(
   ({ state, currentState, onStateChange }: StateButtonProps) => {
     const handleClick = useCallback(
       () => onStateChange(state.state),
-      [onStateChange, state.state]
+      [onStateChange, state.state],
     );
     return (
       <Tooltip key={state.state}>
@@ -78,7 +77,7 @@ const StateButton = memo(
         <TooltipContent>{state.label}</TooltipContent>
       </Tooltip>
     );
-  }
+  },
 );
 
 StateButton.displayName = "StateButton";

--- a/.agents/skills/ai-elements/scripts/persona-opal.tsx
+++ b/.agents/skills/ai-elements/scripts/persona-opal.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import type { PersonaState } from "@/components/ai-elements/persona";
 import type { LucideIcon } from "lucide-react";
-
-import { Persona } from "@/components/ai-elements/persona";
-import { Button } from "@/components/ui/button";
-import { ButtonGroup } from "@/components/ui/button-group";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import {
   BrainIcon,
   CircleIcon,
@@ -19,6 +9,15 @@ import {
   MicIcon,
 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
+import type { PersonaState } from "@/components/ai-elements/persona";
+import { Persona } from "@/components/ai-elements/persona";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface StateButtonProps {
   state: { state: PersonaState; icon: LucideIcon; label: string };
@@ -30,7 +29,7 @@ const StateButton = memo(
   ({ state, currentState, onStateChange }: StateButtonProps) => {
     const handleClick = useCallback(
       () => onStateChange(state.state),
-      [onStateChange, state.state]
+      [onStateChange, state.state],
     );
     return (
       <Tooltip key={state.state}>
@@ -46,7 +45,7 @@ const StateButton = memo(
         <TooltipContent>{state.label}</TooltipContent>
       </Tooltip>
     );
-  }
+  },
 );
 
 StateButton.displayName = "StateButton";

--- a/.agents/skills/ai-elements/scripts/plan.tsx
+++ b/.agents/skills/ai-elements/scripts/plan.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FileText } from "lucide-react";
 import {
   Plan,
   PlanAction,
@@ -11,7 +12,6 @@ import {
   PlanTrigger,
 } from "@/components/ai-elements/plan";
 import { Button } from "@/components/ui/button";
-import { FileText } from "lucide-react";
 
 const Example = () => (
   <Plan defaultOpen={false}>

--- a/.agents/skills/ai-elements/scripts/prompt-input-cursor.tsx
+++ b/.agents/skills/ai-elements/scripts/prompt-input-cursor.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import type { AttachmentData } from "@/components/ai-elements/attachments";
-import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { SourceDocumentUIPart } from "ai";
-
+import {
+  AtSignIcon,
+  CheckIcon,
+  FilesIcon,
+  GlobeIcon,
+  ImageIcon,
+  RulerIcon,
+} from "lucide-react";
+import { memo, useCallback, useState } from "react";
+import type { AttachmentData } from "@/components/ai-elements/attachments";
 import {
   Attachment,
   AttachmentInfo,
@@ -24,6 +31,7 @@ import {
   ModelSelectorName,
   ModelSelectorTrigger,
 } from "@/components/ai-elements/model-selector";
+import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import {
   PromptInput,
   PromptInputBody,
@@ -52,15 +60,6 @@ import {
   usePromptInputReferencedSources,
 } from "@/components/ai-elements/prompt-input";
 import { Button } from "@/components/ui/button";
-import {
-  AtSignIcon,
-  CheckIcon,
-  FilesIcon,
-  GlobeIcon,
-  ImageIcon,
-  RulerIcon,
-} from "lucide-react";
-import { memo, useCallback, useState } from "react";
 
 const models = [
   {
@@ -111,7 +110,7 @@ interface AttachmentItemProps {
 const AttachmentItem = memo(({ attachment, onRemove }: AttachmentItemProps) => {
   const handleRemove = useCallback(
     () => onRemove(attachment.id),
-    [onRemove, attachment.id]
+    [onRemove, attachment.id],
   );
   return (
     <Attachment data={attachment} key={attachment.id} onRemove={handleRemove}>
@@ -131,7 +130,7 @@ interface SourceItemProps {
 const SourceItem = memo(({ source, onRemove }: SourceItemProps) => {
   const handleRemove = useCallback(
     () => onRemove(source.id),
-    [onRemove, source.id]
+    [onRemove, source.id],
   );
   return (
     <Attachment data={source} key={source.id} onRemove={handleRemove}>
@@ -195,7 +194,7 @@ const SourceCommandItem = memo(
         </div>
       </PromptInputCommandItem>
     );
-  }
+  },
 );
 
 SourceCommandItem.displayName = "SourceCommandItem";
@@ -241,7 +240,7 @@ const PromptInputAttachmentsDisplay = () => {
 
   const handleRemove = useCallback(
     (id: string) => attachments.remove(id),
-    [attachments]
+    [attachments],
   );
 
   if (attachments.files.length === 0) {
@@ -464,7 +463,7 @@ const SampleFilesMenu = () => {
 
   const handleAdd = useCallback(
     (source: SourceDocumentUIPart) => refs.add(source),
-    [refs]
+    [refs],
   );
 
   return (
@@ -491,8 +490,8 @@ const SampleFilesMenu = () => {
               (source) =>
                 !refs.sources.some(
                   (s) =>
-                    s.title === source.title && s.filename === source.filename
-                )
+                    s.title === source.title && s.filename === source.filename,
+                ),
             )
             .map((source, index) => (
               <SourceCommandItem

--- a/.agents/skills/ai-elements/scripts/prompt-input-tooltip.tsx
+++ b/.agents/skills/ai-elements/scripts/prompt-input-tooltip.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { GlobeIcon, MicIcon, PaperclipIcon } from "lucide-react";
 import {
   PromptInput,
   PromptInputBody,
@@ -9,7 +10,6 @@ import {
   PromptInputTextarea,
   PromptInputTools,
 } from "@/components/ai-elements/prompt-input";
-import { GlobeIcon, MicIcon, PaperclipIcon } from "lucide-react";
 
 const handleSubmit = () => {
   // Handle submit

--- a/.agents/skills/ai-elements/scripts/prompt-input.tsx
+++ b/.agents/skills/ai-elements/scripts/prompt-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
-
+import { CheckIcon, GlobeIcon } from "lucide-react";
+import { memo, useCallback, useState } from "react";
 import {
   Attachment,
   AttachmentPreview,
@@ -21,6 +21,7 @@ import {
   ModelSelectorName,
   ModelSelectorTrigger,
 } from "@/components/ai-elements/model-selector";
+import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import {
   PromptInput,
   PromptInputActionAddAttachments,
@@ -36,8 +37,6 @@ import {
   PromptInputTools,
   usePromptInputAttachments,
 } from "@/components/ai-elements/prompt-input";
-import { CheckIcon, GlobeIcon } from "lucide-react";
-import { memo, useCallback, useState } from "react";
 
 const models = [
   {
@@ -94,7 +93,7 @@ interface AttachmentItemProps {
 const AttachmentItem = memo(({ attachment, onRemove }: AttachmentItemProps) => {
   const handleRemove = useCallback(
     () => onRemove(attachment.id),
-    [onRemove, attachment.id]
+    [onRemove, attachment.id],
   );
   return (
     <Attachment data={attachment} key={attachment.id} onRemove={handleRemove}>
@@ -139,7 +138,7 @@ const PromptInputAttachmentsDisplay = () => {
 
   const handleRemove = useCallback(
     (id: string) => attachments.remove(id),
-    [attachments]
+    [attachments],
   );
 
   if (attachments.files.length === 0) {

--- a/.agents/skills/ai-elements/scripts/queue-prompt-input.tsx
+++ b/.agents/skills/ai-elements/scripts/queue-prompt-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
-import type { QueueTodo } from "@/components/ai-elements/queue";
+import { CheckIcon, GlobeIcon, Trash2 } from "lucide-react";
+import { memo, useCallback, useRef, useState } from "react";
 
 import {
   Attachment,
@@ -22,6 +22,7 @@ import {
   ModelSelectorName,
   ModelSelectorTrigger,
 } from "@/components/ai-elements/model-selector";
+import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import {
   PromptInput,
   PromptInputActionAddAttachments,
@@ -37,6 +38,7 @@ import {
   PromptInputTools,
   usePromptInputAttachments,
 } from "@/components/ai-elements/prompt-input";
+import type { QueueTodo } from "@/components/ai-elements/queue";
 import {
   Queue,
   QueueItem,
@@ -48,8 +50,6 @@ import {
   QueueSection,
   QueueSectionContent,
 } from "@/components/ai-elements/queue";
-import { CheckIcon, GlobeIcon, Trash2 } from "lucide-react";
-import { memo, useCallback, useRef, useState } from "react";
 
 const models = [
   {
@@ -106,7 +106,7 @@ interface AttachmentItemProps {
 const AttachmentItem = memo(({ attachment, onRemove }: AttachmentItemProps) => {
   const handleRemove = useCallback(
     () => onRemove(attachment.id),
-    [onRemove, attachment.id]
+    [onRemove, attachment.id],
   );
   return (
     <Attachment data={attachment} key={attachment.id} onRemove={handleRemove}>
@@ -127,7 +127,7 @@ const TodoItem = memo(({ todo, onRemove }: TodoItemProps) => {
   const isCompleted = todo.status === "completed";
   const handleRemove = useCallback(
     () => onRemove(todo.id),
-    [onRemove, todo.id]
+    [onRemove, todo.id],
   );
 
   return (
@@ -219,7 +219,7 @@ const PromptInputAttachmentsDisplay = () => {
 
   const handleRemove = useCallback(
     (id: string) => attachments.remove(id),
-    [attachments]
+    [attachments],
   );
 
   if (attachments.files.length === 0) {
@@ -256,7 +256,7 @@ const Example = () => {
 
   const handleTextChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value),
-    []
+    [],
   );
 
   const handleModelSelect = useCallback((id: string) => {
@@ -306,7 +306,7 @@ const Example = () => {
         timeoutRef.current = null;
       }, STREAMING_TIMEOUT);
     },
-    [status]
+    [status],
   );
 
   return (

--- a/.agents/skills/ai-elements/scripts/queue.tsx
+++ b/.agents/skills/ai-elements/scripts/queue.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { ArrowUp, Trash2 } from "lucide-react";
+import { memo, useCallback, useState } from "react";
 import type { QueueMessage, QueueTodo } from "@/components/ai-elements/queue";
-
 import {
   Queue,
   QueueItem,
@@ -19,8 +20,6 @@ import {
   QueueSectionLabel,
   QueueSectionTrigger,
 } from "@/components/ai-elements/queue";
-import { ArrowUp, Trash2 } from "lucide-react";
-import { memo, useCallback, useState } from "react";
 
 const sampleMessages: QueueMessage[] = [
   {
@@ -103,11 +102,11 @@ const MessageActions = memo(
   ({ messageId, onRemove, onSend }: MessageActionsProps) => {
     const handleRemove = useCallback(
       (e: React.MouseEvent) => onRemove(e, messageId),
-      [onRemove, messageId]
+      [onRemove, messageId],
     );
     const handleSend = useCallback(
       (e: React.MouseEvent) => onSend(e, messageId),
-      [onSend, messageId]
+      [onSend, messageId],
     );
     return (
       <QueueItemActions>
@@ -123,7 +122,7 @@ const MessageActions = memo(
         </QueueItemAction>
       </QueueItemActions>
     );
-  }
+  },
 );
 
 MessageActions.displayName = "MessageActions";
@@ -137,7 +136,7 @@ const TodoItem = memo(({ todo, onRemove }: TodoItemProps) => {
   const isCompleted = todo.status === "completed";
   const handleRemove = useCallback(
     () => onRemove(todo.id),
-    [onRemove, todo.id]
+    [onRemove, todo.id],
   );
 
   return (
@@ -187,7 +186,7 @@ const Example = () => {
       e.stopPropagation();
       handleRemoveMessage(id);
     },
-    [handleRemoveMessage]
+    [handleRemoveMessage],
   );
 
   const handleMessageSend = useCallback(
@@ -196,7 +195,7 @@ const Example = () => {
       e.stopPropagation();
       handleSendNow(id);
     },
-    [handleSendNow]
+    [handleSendNow],
   );
 
   if (messages.length === 0 && todos.length === 0) {
@@ -215,7 +214,7 @@ const Example = () => {
               {messages.map((message) => {
                 const summary = (() => {
                   const textParts = message.parts.filter(
-                    (p) => p.type === "text"
+                    (p) => p.type === "text",
                   );
                   const text = textParts
                     .map((p) => p.text)
@@ -225,7 +224,7 @@ const Example = () => {
                 })();
 
                 const hasFiles = message.parts.some(
-                  (p) => p.type === "file" && p.url
+                  (p) => p.type === "file" && p.url,
                 );
 
                 return (

--- a/.agents/skills/ai-elements/scripts/reasoning.tsx
+++ b/.agents/skills/ai-elements/scripts/reasoning.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import {
   Reasoning,
   ReasoningContent,
   ReasoningTrigger,
 } from "@/components/ai-elements/reasoning";
-import { useCallback, useEffect, useState } from "react";
 
 const reasoningSteps = [
   "Let me think about this problem step by step.",

--- a/.agents/skills/ai-elements/scripts/sandbox.tsx
+++ b/.agents/skills/ai-elements/scripts/sandbox.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import type { ToolUIPart } from "ai";
-
-import { CodeBlock, CodeBlockCopyButton } from "@/components/ai-elements/code-block";
+import { memo, useCallback, useState } from "react";
+import {
+  CodeBlock,
+  CodeBlockCopyButton,
+} from "@/components/ai-elements/code-block";
 import {
   Sandbox,
   SandboxContent,
@@ -26,7 +29,6 @@ import {
   StackTraceHeader,
 } from "@/components/ai-elements/stack-trace";
 import { Button } from "@/components/ui/button";
-import { memo, useCallback, useState } from "react";
 
 const code = `import math
 
@@ -86,7 +88,7 @@ const StateButton = memo(
         {s}
       </Button>
     );
-  }
+  },
 );
 
 StateButton.displayName = "StateButton";

--- a/.agents/skills/ai-elements/scripts/sources-custom.tsx
+++ b/.agents/skills/ai-elements/scripts/sources-custom.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { ChevronDownIcon, ExternalLinkIcon } from "lucide-react";
 import {
   Source,
   Sources,
   SourcesContent,
   SourcesTrigger,
 } from "@/components/ai-elements/sources";
-import { ChevronDownIcon, ExternalLinkIcon } from "lucide-react";
 
 const sources = [
   { href: "https://stripe.com/docs/api", title: "Stripe API Documentation" },

--- a/.agents/skills/ai-elements/scripts/speech-input.tsx
+++ b/.agents/skills/ai-elements/scripts/speech-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { SpeechInput } from "@/components/ai-elements/speech-input";
 import { useCallback, useState } from "react";
+import { SpeechInput } from "@/components/ai-elements/speech-input";
 
 /**
  * Fallback handler for browsers that don't support Web Speech API (Firefox, Safari).
@@ -21,7 +21,7 @@ const handleAudioRecorded = async (audioBlob: Blob): Promise<string> => {
         Authorization: `Bearer ${process.env.NEXT_PUBLIC_OPENAI_API_KEY}`,
       },
       method: "POST",
-    }
+    },
   );
 
   if (!response.ok) {

--- a/.agents/skills/ai-elements/scripts/suggestion-input.tsx
+++ b/.agents/skills/ai-elements/scripts/suggestion-input.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { GlobeIcon, MicIcon, PlusIcon, SendIcon } from "lucide-react";
+import { nanoid } from "nanoid";
+import { memo, useCallback, useState } from "react";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
-
 import {
   PromptInput,
   PromptInputButton,
@@ -16,9 +18,6 @@ import {
   PromptInputTools,
 } from "@/components/ai-elements/prompt-input";
 import { Suggestion, Suggestions } from "@/components/ai-elements/suggestion";
-import { GlobeIcon, MicIcon, PlusIcon, SendIcon } from "lucide-react";
-import { nanoid } from "nanoid";
-import { memo, useCallback, useState } from "react";
 
 const suggestions: { key: string; value: string }[] = [
   { key: nanoid(), value: "What are the latest trends in AI?" },
@@ -64,7 +63,7 @@ const SuggestionItem = memo(
   ({ suggestion, onSuggestionClick }: SuggestionItemProps) => {
     const handleClick = useCallback(
       () => onSuggestionClick(suggestion.value),
-      [onSuggestionClick, suggestion.value]
+      [onSuggestionClick, suggestion.value],
     );
     return (
       <Suggestion
@@ -73,7 +72,7 @@ const SuggestionItem = memo(
         suggestion={suggestion.value}
       />
     );
-  }
+  },
 );
 
 SuggestionItem.displayName = "SuggestionItem";
@@ -88,7 +87,7 @@ const Example = () => {
 
   const handleTextChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value),
-    []
+    [],
   );
 
   return (

--- a/.agents/skills/ai-elements/scripts/task.tsx
+++ b/.agents/skills/ai-elements/scripts/task.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type { ReactNode } from "react";
-
 import { SiReact } from "@icons-pack/react-simple-icons";
+import { nanoid } from "nanoid";
+import type { ReactNode } from "react";
 import {
   Task,
   TaskContent,
@@ -10,7 +10,6 @@ import {
   TaskItemFile,
   TaskTrigger,
 } from "@/components/ai-elements/task";
-import { nanoid } from "nanoid";
 
 const Example = () => {
   const tasks: { key: string; value: ReactNode }[] = [

--- a/.agents/skills/ai-elements/scripts/terminal-clear.tsx
+++ b/.agents/skills/ai-elements/scripts/terminal-clear.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Terminal } from "@/components/ai-elements/terminal";
 import { useCallback, useState } from "react";
+import { Terminal } from "@/components/ai-elements/terminal";
 
 const initialOutput = `\u001B[36m$\u001B[0m npm run build
 Building project...

--- a/.agents/skills/ai-elements/scripts/terminal-streaming.tsx
+++ b/.agents/skills/ai-elements/scripts/terminal-streaming.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Terminal } from "@/components/ai-elements/terminal";
 import { useEffect, useState } from "react";
+import { Terminal } from "@/components/ai-elements/terminal";
 
 const lines = [
   "\u001B[36m$\u001B[0m npm install",

--- a/.agents/skills/ai-elements/scripts/terminal.tsx
+++ b/.agents/skills/ai-elements/scripts/terminal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import {
   Terminal,
   TerminalActions,
@@ -10,7 +11,6 @@ import {
   TerminalStatus,
   TerminalTitle,
 } from "@/components/ai-elements/terminal";
-import { useCallback, useEffect, useState } from "react";
 
 const handleTerminalCopy = () => {
   console.log("Copied!");

--- a/.agents/skills/ai-elements/scripts/tool-input-available.tsx
+++ b/.agents/skills/ai-elements/scripts/tool-input-available.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { Tool, ToolContent, ToolHeader, ToolInput } from "@/components/ai-elements/tool";
 import { nanoid } from "nanoid";
+import {
+  Tool,
+  ToolContent,
+  ToolHeader,
+  ToolInput,
+} from "@/components/ai-elements/tool";
 
 const toolCall = {
   errorText: undefined,

--- a/.agents/skills/ai-elements/scripts/tool-input-streaming.tsx
+++ b/.agents/skills/ai-elements/scripts/tool-input-streaming.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { Tool, ToolContent, ToolHeader, ToolInput } from "@/components/ai-elements/tool";
 import { nanoid } from "nanoid";
+import {
+  Tool,
+  ToolContent,
+  ToolHeader,
+  ToolInput,
+} from "@/components/ai-elements/tool";
 
 const toolCall = {
   errorText: undefined,

--- a/.agents/skills/ai-elements/scripts/tool-output-available.tsx
+++ b/.agents/skills/ai-elements/scripts/tool-output-available.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ToolUIPart } from "ai";
-
+import { nanoid } from "nanoid";
 import { CodeBlock } from "@/components/ai-elements/code-block";
 import {
   Tool,
@@ -10,7 +10,6 @@ import {
   ToolInput,
   ToolOutput,
 } from "@/components/ai-elements/tool";
-import { nanoid } from "nanoid";
 
 const toolCall: ToolUIPart = {
   errorText: undefined,

--- a/.agents/skills/ai-elements/scripts/tool.tsx
+++ b/.agents/skills/ai-elements/scripts/tool.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { ToolUIPart } from "ai";
-
+import { CheckIcon, XIcon } from "lucide-react";
+import { nanoid } from "nanoid";
 import {
   Confirmation,
   ConfirmationAccepted,
@@ -18,8 +19,6 @@ import {
   ToolInput,
   ToolOutput,
 } from "@/components/ai-elements/tool";
-import { CheckIcon, XIcon } from "lucide-react";
-import { nanoid } from "nanoid";
 
 const handleReject = () => {
   // In production, call addConfirmationResponse

--- a/.agents/skills/ai-elements/scripts/transcription.tsx
+++ b/.agents/skills/ai-elements/scripts/transcription.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import type { Experimental_TranscriptionResult as TranscriptionResult } from "ai";
-
+import { useCallback, useRef, useState } from "react";
 import {
   Transcription,
   TranscriptionSegment,
 } from "@/components/ai-elements/transcription";
-import { useCallback, useRef, useState } from "react";
 
 const segments: TranscriptionResult["segments"] = [
   {

--- a/.agents/skills/ai-elements/scripts/voice-selector.tsx
+++ b/.agents/skills/ai-elements/scripts/voice-selector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ComponentProps } from "react";
-
+import { memo, useCallback, useRef, useState } from "react";
 import {
   VoiceSelector,
   VoiceSelectorAccent,
@@ -19,7 +19,6 @@ import {
   VoiceSelectorTrigger,
 } from "@/components/ai-elements/voice-selector";
 import { Button } from "@/components/ui/button";
-import { memo, useCallback, useRef, useState } from "react";
 
 const voices: {
   id: string;
@@ -110,11 +109,11 @@ const VoiceItem = memo(
   }: VoiceItemProps) => {
     const handleSelect = useCallback(
       () => onSelect(voice.id),
-      [onSelect, voice.id]
+      [onSelect, voice.id],
     );
     const handlePreview = useCallback(
       () => onPreview(voice.id),
-      [onPreview, voice.id]
+      [onPreview, voice.id],
     );
     return (
       <VoiceSelectorItem
@@ -137,7 +136,7 @@ const VoiceItem = memo(
         <VoiceSelectorGender value={voice.gender} />
       </VoiceSelectorItem>
     );
-  }
+  },
 );
 
 VoiceItem.displayName = "VoiceItem";
@@ -196,7 +195,7 @@ const Example = () => {
 
       audio.load();
     },
-    [playingVoice]
+    [playingVoice],
   );
 
   const selectedVoiceData = voices.find((voice) => voice.id === selectedVoice);

--- a/.agents/skills/ai-elements/scripts/web-preview.tsx
+++ b/.agents/skills/ai-elements/scripts/web-preview.tsx
@@ -1,14 +1,6 @@
 "use client";
 
 import {
-  WebPreview,
-  WebPreviewBody,
-  WebPreviewConsole,
-  WebPreviewNavigation,
-  WebPreviewNavigationButton,
-  WebPreviewUrl,
-} from "@/components/ai-elements/web-preview";
-import {
   ArrowLeftIcon,
   ArrowRightIcon,
   ExternalLinkIcon,
@@ -17,6 +9,14 @@ import {
   RefreshCcwIcon,
 } from "lucide-react";
 import { useCallback, useState } from "react";
+import {
+  WebPreview,
+  WebPreviewBody,
+  WebPreviewConsole,
+  WebPreviewNavigation,
+  WebPreviewNavigationButton,
+  WebPreviewUrl,
+} from "@/components/ai-elements/web-preview";
 
 const handleUrlChange = (url: string) => {
   console.log("URL changed to:", url);
@@ -65,7 +65,7 @@ const Example = () => {
 
   const handleToggleFullscreen = useCallback(
     () => setFullscreen((prev) => !prev),
-    []
+    [],
   );
 
   return (

--- a/app/video/youtube/[youtubeId]/analyze/_components/eager-slide-extraction.tsx
+++ b/app/video/youtube/[youtubeId]/analyze/_components/eager-slide-extraction.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Fire-and-forget component that triggers slide extraction as soon as the
+ * analyze layout mounts, instead of waiting for the user to navigate to
+ * the slides-selection tab. The POST endpoint is idempotent — it returns
+ * 409 if extraction is already completed or in progress.
+ */
+export function EagerSlideExtraction({ videoId }: { videoId: string }) {
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+
+    fetch(`/api/video/${videoId}/slides`, { method: "POST" }).catch(() => {
+      // Silently ignore — the slides panel will handle errors when the user
+      // navigates to it. This is purely a best-effort early start.
+    });
+  }, [videoId]);
+
+  return null;
+}

--- a/app/video/youtube/[youtubeId]/analyze/_components/eager-slide-extraction.tsx
+++ b/app/video/youtube/[youtubeId]/analyze/_components/eager-slide-extraction.tsx
@@ -9,16 +9,29 @@ import { useEffect, useRef } from "react";
  * 409 if extraction is already completed or in progress.
  */
 export function EagerSlideExtraction({ videoId }: { videoId: string }) {
-  const firedRef = useRef(false);
+  const firedForRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (firedRef.current) return;
-    firedRef.current = true;
+    if (firedForRef.current === videoId) return;
+    firedForRef.current = videoId;
 
-    fetch(`/api/video/${videoId}/slides`, { method: "POST" }).catch(() => {
-      // Silently ignore — the slides panel will handle errors when the user
-      // navigates to it. This is purely a best-effort early start.
-    });
+    const controller = new AbortController();
+
+    fetch(`/api/video/${videoId}/slides`, {
+      method: "POST",
+      signal: controller.signal,
+    })
+      .then(() => {
+        // Close the connection immediately since we only care about
+        // triggering the workflow, not consuming the SSE stream.
+        controller.abort();
+      })
+      .catch(() => {
+        // Silently ignore — the slides panel will handle errors when the user
+        // navigates to it. This is purely a best-effort early start.
+      });
+
+    return () => controller.abort();
   }, [videoId]);
 
   return null;

--- a/app/video/youtube/[youtubeId]/analyze/layout.tsx
+++ b/app/video/youtube/[youtubeId]/analyze/layout.tsx
@@ -7,6 +7,7 @@ import { fetchAndSaveTranscript } from "@/lib/fetch-and-save-transcript";
 import { isValidYouTubeVideoId } from "@/lib/youtube-utils";
 import { AnalyzeLayoutSidebar } from "./_components/analyze-layout-sidebar";
 import { AnalyzeNav } from "./_components/analyze-nav";
+import { EagerSlideExtraction } from "./_components/eager-slide-extraction";
 
 interface AnalyzeLayoutProps {
   children: React.ReactNode;
@@ -72,6 +73,7 @@ export default async function AnalyzeLayout({
             </div>
           </header>
 
+          <EagerSlideExtraction videoId={youtubeId} />
           <main className="flex-1">
             <div className="mx-auto max-w-5xl px-4 py-6 md:px-6">
               {children}

--- a/biome.json
+++ b/biome.json
@@ -7,14 +7,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": [
-      "**",
-      "!node_modules",
-      "!.next",
-      "!dist",
-      "!build",
-      "!.agents/**"
-    ]
+    "includes": ["**", "!node_modules", "!.next", "!dist", "!build", "!.agents"]
   },
   "formatter": {
     "enabled": true,

--- a/lib/use-slide-queries.ts
+++ b/lib/use-slide-queries.ts
@@ -8,6 +8,8 @@ import type {
 } from "./api-types";
 import type { SlideAnalysisTarget } from "./slides-types";
 
+const SLIDES_POLL_INTERVAL_MS = 3000;
+
 export function useSlidesQuery(videoId: string) {
   return useQuery<SlidesResponse>({
     queryKey: ["slides", videoId],
@@ -17,6 +19,15 @@ export function useSlidesQuery(videoId: string) {
       return response.json();
     },
     staleTime: Number.POSITIVE_INFINITY, // Slides never change once extracted
+    // Poll while extraction is in progress so we pick up completion from the
+    // eagerly-started workflow (which runs independently of any SSE stream).
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status === "in_progress" || status === "pending") {
+        return SLIDES_POLL_INTERVAL_MS;
+      }
+      return false;
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
This PR optimizes the slide extraction workflow by starting the extraction process as soon as the analyze layout mounts, rather than waiting for the user to navigate to the slides-selection tab. This reduces perceived latency when users need to view extracted slides.

## Key Changes
- **New `EagerSlideExtraction` component**: A fire-and-forget client component that triggers the slide extraction POST endpoint immediately when the analyze layout loads. Errors are silently ignored since the slides panel will handle them when the user navigates to it.
- **Updated `useSlidesQuery` hook**: Added polling logic that checks for slide extraction completion every 3 seconds while the status is "in_progress" or "pending". This allows the UI to pick up completion from the eagerly-started workflow without relying on SSE streams.
- **Minor config cleanup**: Simplified the biome.json file includes pattern for consistency.

## Implementation Details
- The `EagerSlideExtraction` component uses a `useRef` to ensure the extraction request fires only once, even if the component re-renders.
- The POST endpoint is idempotent and returns 409 if extraction is already completed or in progress, making it safe to call eagerly.
- Polling is conditional and only active during extraction; once complete or failed, polling stops to avoid unnecessary requests.

https://claude.ai/code/session_01Ph4Jq8QnsR51eq7cyDVFCm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic slide extraction now triggers when viewing video analysis pages
  * Added real-time progress tracking for slide extraction status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->